### PR TITLE
MONGOSH-89: Add global compass shell component role

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The Compass plugin responsible for gluing together other plugins:
 - [compass-schema-validation][compass-schema-validation]
 - [compass-server-version][compass-server-version]
 - [compass-serverstats][compass-serverstats]
+- [compass-shell][compass-shell]
 - [compass-sidebar][compass-sidebar]
 - [compass-ssh-tunnel-status][compass-ssh-tunnel-status]
 - [compass-status][compass-status]
@@ -129,6 +130,7 @@ Apache 2.0
 [compass-schema-validation]: https://github.com/mongodb-js/compass-schema-validation
 [compass-server-version]: https://github.com/mongodb-js/compass-server-version
 [compass-serverstats]: https://github.com/mongodb-js/compass-serverstats
+[compass-shell]: https://github.com/mongodb-js/mongosh/tree/master/packages/compass-shell
 [compass-sidebar]: https://github.com/mongodb-js/compass-sidebar
 [compass-ssh-tunnel-status]: https://github.com/mongodb-js/compass-ssh-tunnel-status
 [compass-status]: https://github.com/mongodb-js/compass-status

--- a/package-lock.json
+++ b/package-lock.json
@@ -2265,14 +2265,14 @@
       }
     },
     "@mongodb-js/compass-shell": {
-      "version": "0.0.1-alpha.13",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-shell/-/compass-shell-0.0.1-alpha.13.tgz",
-      "integrity": "sha512-vKBKRGU+sDAOU2oXMWtcDd5QA6qRJ/tzvsw85R2YL5BDOvrFDBqpT7B79MqQRKXWG76oBRnzaoGwPaMd41SiOQ==",
+      "version": "0.0.1-alpha.14",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-shell/-/compass-shell-0.0.1-alpha.14.tgz",
+      "integrity": "sha512-BnrG0Sq5TYlM8wInfxP2N4oaPH4S06nZG2Q9s0eqtQ0Y5Dvt5QUoEcn8hS8M+I5NTcrR/Pglf4y6JB+vRjSjdw==",
       "dev": true,
       "requires": {
-        "@mongosh/browser-repl": "^0.0.1-alpha.13",
-        "@mongosh/browser-runtime-electron": "^0.0.1-alpha.13",
-        "@mongosh/service-provider-server": "^0.0.1-alpha.13"
+        "@mongosh/browser-repl": "^0.0.1-alpha.14",
+        "@mongosh/browser-runtime-electron": "^0.0.1-alpha.14",
+        "@mongosh/service-provider-server": "^0.0.1-alpha.14"
       }
     },
     "@mongodb-js/compass-sidebar": {
@@ -2306,9 +2306,9 @@
       }
     },
     "@mongosh/async-rewriter": {
-      "version": "0.0.1-alpha.13",
-      "resolved": "https://registry.npmjs.org/@mongosh/async-rewriter/-/async-rewriter-0.0.1-alpha.13.tgz",
-      "integrity": "sha512-fpgz00RK2440Nh/FygNYcaMzX7DAN2nDhzQO6PoFUklMvB66IjVjuPmM+eNCb4qMc46oZYsz8PgeNo6lu/JCRg==",
+      "version": "0.0.1-alpha.14",
+      "resolved": "https://registry.npmjs.org/@mongosh/async-rewriter/-/async-rewriter-0.0.1-alpha.14.tgz",
+      "integrity": "sha512-Bo2WxKaHo0i+9fyCopYzQFGQlPUcpLCOhz3nTOAkFOVZbIGVwrTnKu3cVAovRs/Lxn8CIenxVAvDOJ0CO4dRwg==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.9.0",
@@ -2317,7 +2317,7 @@
         "@babel/template": "^7.8.6",
         "@babel/traverse": "^7.9.0",
         "@babel/types": "^7.9.0",
-        "@mongosh/errors": "^0.0.1-alpha.13",
+        "@mongosh/errors": "^0.0.1-alpha.14",
         "@types/babel__core": "^7.1.6",
         "@types/babel__traverse": "^7.0.9",
         "ts-node": "^8.8.1",
@@ -2478,9 +2478,9 @@
       }
     },
     "@mongosh/browser-repl": {
-      "version": "0.0.1-alpha.13",
-      "resolved": "https://registry.npmjs.org/@mongosh/browser-repl/-/browser-repl-0.0.1-alpha.13.tgz",
-      "integrity": "sha512-eXGHMFhdDZ7Qs3+iadNOYk07eoPUg6vCDBGcCWq3vYWmKRWfYJpXSU83EhdQp4XK2FTbaNwuiat56M3TPCh9Uw==",
+      "version": "0.0.1-alpha.14",
+      "resolved": "https://registry.npmjs.org/@mongosh/browser-repl/-/browser-repl-0.0.1-alpha.14.tgz",
+      "integrity": "sha512-+zitcvptvUMsOZo/5ZpoCiEc23rqKn+aMazKovYLzGdk981vyOGhyzc+iTW7ErfOU2pq5eYLvA++nylY8kZHrw==",
       "dev": true,
       "requires": {
         "@babel/generator": "^7.8.3",
@@ -2490,10 +2490,10 @@
         "@leafygreen-ui/icon": "^4.0.0",
         "@leafygreen-ui/palette": "^2.0.0",
         "@leafygreen-ui/syntax": "^2.2.0",
-        "@mongosh/browser-runtime-core": "^0.0.1-alpha.13",
-        "@mongosh/history": "^0.0.1-alpha.13",
-        "@mongosh/i18n": "^0.0.1-alpha.13",
-        "@mongosh/service-provider-core": "^0.0.1-alpha.13",
+        "@mongosh/browser-runtime-core": "^0.0.1-alpha.14",
+        "@mongosh/history": "^0.0.1-alpha.14",
+        "@mongosh/i18n": "^0.0.1-alpha.14",
+        "@mongosh/service-provider-core": "^0.0.1-alpha.14",
         "pretty-bytes": "^5.3.0",
         "text-table": "^0.2.0"
       },
@@ -2507,16 +2507,16 @@
       }
     },
     "@mongosh/browser-runtime-core": {
-      "version": "0.0.1-alpha.13",
-      "resolved": "https://registry.npmjs.org/@mongosh/browser-runtime-core/-/browser-runtime-core-0.0.1-alpha.13.tgz",
-      "integrity": "sha512-K0p0U25utbzfF6ejk4x55YEsq9NoBrZ/V3PFnjniBuLbmGCoLu3ByUR25gbuNastnQvjt59sro4OkQrEFlbzVw==",
+      "version": "0.0.1-alpha.14",
+      "resolved": "https://registry.npmjs.org/@mongosh/browser-runtime-core/-/browser-runtime-core-0.0.1-alpha.14.tgz",
+      "integrity": "sha512-qs44qbMncnI3LHn7QnbNWBQAlmgGjuALC+bsuOSlFkK+zt53ikpX4AeQiS/plQAVijAq1wbHqdyk2Y12xhA+YA==",
       "dev": true,
       "requires": {
         "@babel/generator": "^7.9.4",
         "@babel/parser": "^7.9.4",
-        "@mongosh/cli-repl": "^0.0.1-alpha.13",
-        "@mongosh/service-provider-core": "^0.0.1-alpha.13",
-        "@mongosh/shell-evaluator": "^0.0.1-alpha.13"
+        "@mongosh/cli-repl": "^0.0.1-alpha.14",
+        "@mongosh/service-provider-core": "^0.0.1-alpha.14",
+        "@mongosh/shell-evaluator": "^0.0.1-alpha.14"
       },
       "dependencies": {
         "@babel/generator": {
@@ -2563,28 +2563,36 @@
       }
     },
     "@mongosh/browser-runtime-electron": {
-      "version": "0.0.1-alpha.13",
-      "resolved": "https://registry.npmjs.org/@mongosh/browser-runtime-electron/-/browser-runtime-electron-0.0.1-alpha.13.tgz",
-      "integrity": "sha512-saGjydRsCE43bAY1pMzEaKZFS70oz+CPCZSLhwYrE6bzdzhfPXN7HDJCUzws5wg1waAEh+rRqRq0UnxT0c/rgw==",
+      "version": "0.0.1-alpha.14",
+      "resolved": "https://registry.npmjs.org/@mongosh/browser-runtime-electron/-/browser-runtime-electron-0.0.1-alpha.14.tgz",
+      "integrity": "sha512-BK4bYyU2L5IvT9fHR3B+NzcSFxuG2oqkymM0het5hNcsUuxwppwls2qhaMbFlflXSC6dkOZDae6sfWY79cB5lA==",
       "dev": true,
       "requires": {
-        "@mongosh/browser-runtime-core": "^0.0.1-alpha.13",
-        "@mongosh/service-provider-core": "^0.0.1-alpha.13"
+        "@mongosh/browser-runtime-core": "^0.0.1-alpha.14",
+        "@mongosh/service-provider-core": "^0.0.1-alpha.14"
       }
     },
     "@mongosh/cli-repl": {
-      "version": "0.0.1-alpha.13",
-      "resolved": "https://registry.npmjs.org/@mongosh/cli-repl/-/cli-repl-0.0.1-alpha.13.tgz",
-      "integrity": "sha512-IBUXC46rDBBexctccJ64f4R7zTI5oeqN9AW/sym/F1kyZJK2p7VeRlsCgrLwyg70VZVdAGCkOt88kmPCxirJnQ==",
+      "version": "0.0.1-alpha.14",
+      "resolved": "https://registry.npmjs.org/@mongosh/cli-repl/-/cli-repl-0.0.1-alpha.14.tgz",
+      "integrity": "sha512-DmN7Gz9tlj6C+hNXa80ca6cOKjnfRg4hOkoaJppqKpu/zmUTdkEHsK+K3TF8mw7xutvkuFYN2OOewhirF+le7Q==",
       "dev": true,
       "requires": {
-        "@mongosh/history": "^0.0.1-alpha.13",
-        "@mongosh/i18n": "^0.0.1-alpha.13",
-        "@mongosh/service-provider-server": "^0.0.1-alpha.13",
-        "@mongosh/shell-api": "^0.0.1-alpha.13",
-        "@mongosh/shell-evaluator": "^0.0.1-alpha.13",
+        "@mongosh/errors": "^0.0.1-alpha.14",
+        "@mongosh/history": "^0.0.1-alpha.14",
+        "@mongosh/i18n": "^0.0.1-alpha.14",
+        "@mongosh/service-provider-server": "^0.0.1-alpha.14",
+        "@mongosh/shell-api": "^0.0.1-alpha.14",
+        "@mongosh/shell-evaluator": "^0.0.1-alpha.14",
+        "acorn": "^7.1.1",
+        "acorn-class-fields": "^0.3.2",
+        "acorn-numeric-separator": "^0.3.0",
+        "acorn-private-methods": "^0.3.1",
+        "acorn-static-class-features": "^0.2.1",
+        "analytics-node": "^3.4.0-beta.1",
         "ansi-escape-sequences": "^5.1.2",
         "bson": "^4.0.4",
+        "is-recoverable-error": "^1.0.0",
         "lodash.set": "^4.3.2",
         "minimist": "^1.2.5",
         "mkdirp": "^1.0.3",
@@ -2600,6 +2608,12 @@
         "text-table": "^0.2.0"
       },
       "dependencies": {
+        "acorn": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.2.0.tgz",
+          "integrity": "sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ==",
+          "dev": true
+        },
         "bson": {
           "version": "4.0.4",
           "resolved": "https://registry.npmjs.org/bson/-/bson-4.0.4.tgz",
@@ -2637,38 +2651,38 @@
       }
     },
     "@mongosh/errors": {
-      "version": "0.0.1-alpha.13",
-      "resolved": "https://registry.npmjs.org/@mongosh/errors/-/errors-0.0.1-alpha.13.tgz",
-      "integrity": "sha512-jJ5s2lpszODjYm8FH7+zhf2tAXTFnsUMchdUYlIxfcodr3QzQJNxySrmj0C9jwddwvFQ5zzxkJDtA4EUcF+YaA==",
+      "version": "0.0.1-alpha.14",
+      "resolved": "https://registry.npmjs.org/@mongosh/errors/-/errors-0.0.1-alpha.14.tgz",
+      "integrity": "sha512-cjiIbqbMNvOmj048xZkuINcfj/NBlru5Eq2cb5PFP1YcDCLwKhL+sw2KidbQZ3K5+of6IFNCLJ1H0kAInEXREQ==",
       "dev": true
     },
     "@mongosh/history": {
-      "version": "0.0.1-alpha.13",
-      "resolved": "https://registry.npmjs.org/@mongosh/history/-/history-0.0.1-alpha.13.tgz",
-      "integrity": "sha512-qZjTKYxmP8VsPTXVWpaVpyPQTcJo7UrcOnN1uvPtmLXJ6s6yny7rSFYi+QPqahheShrb062YjnNGyUSdI/qSEw==",
+      "version": "0.0.1-alpha.14",
+      "resolved": "https://registry.npmjs.org/@mongosh/history/-/history-0.0.1-alpha.14.tgz",
+      "integrity": "sha512-q4EJN8lOIsXOMM9mQ89Cy5mzE6MyM8isyvtbFYm9TDbzgcMiO9Tzeh1cVpKDk+fd3HFGeYfoijtL6lOu0BmyNw==",
       "dev": true,
       "requires": {
         "mongodb-redact": "^0.2.0"
       }
     },
     "@mongosh/i18n": {
-      "version": "0.0.1-alpha.13",
-      "resolved": "https://registry.npmjs.org/@mongosh/i18n/-/i18n-0.0.1-alpha.13.tgz",
-      "integrity": "sha512-afSXLbzsW+F9zbeN0T1cc6VwmDrOjr5qQzF+r5KYvz6Z3tbkJf6uxct9m6YicNy2qxnGKDQtQ2lMdtmFXV5Ptw==",
+      "version": "0.0.1-alpha.14",
+      "resolved": "https://registry.npmjs.org/@mongosh/i18n/-/i18n-0.0.1-alpha.14.tgz",
+      "integrity": "sha512-At1NP1/c1by4CCR25uEmJHMdbXAKZoeef2m3EZQMqTklXPoIQtCYItlRmF+yHD0B5ObIm4TZLss2NrLtLKiOrw==",
       "dev": true,
       "requires": {
         "mustache": "^4.0.0"
       }
     },
     "@mongosh/mapper": {
-      "version": "0.0.1-alpha.13",
-      "resolved": "https://registry.npmjs.org/@mongosh/mapper/-/mapper-0.0.1-alpha.13.tgz",
-      "integrity": "sha512-UHT7jpH5bVBkJFXn27H7R9/PjOh0O4DWT1Mog47ib9PXZAf2fy2GtSWWV8Zmamjg2ewBJv5vLd9VAqMyqCnruA==",
+      "version": "0.0.1-alpha.14",
+      "resolved": "https://registry.npmjs.org/@mongosh/mapper/-/mapper-0.0.1-alpha.14.tgz",
+      "integrity": "sha512-JijmqyAeuO1ZpSRnBG9RzGRV8ZhNhqdwDhBk3QRlz8ze/Z4XONRFiFUKH4wnwBFj79qw3y+r+SiwnXnv975v8Q==",
       "dev": true,
       "requires": {
-        "@mongosh/errors": "^0.0.1-alpha.13",
-        "@mongosh/service-provider-core": "^0.0.1-alpha.13",
-        "@mongosh/shell-api": "^0.0.1-alpha.13",
+        "@mongosh/errors": "^0.0.1-alpha.14",
+        "@mongosh/service-provider-core": "^0.0.1-alpha.14",
+        "@mongosh/shell-api": "^0.0.1-alpha.14",
         "pretty-bytes": "^5.3.0",
         "text-table": "^0.2.0"
       },
@@ -2682,18 +2696,18 @@
       }
     },
     "@mongosh/service-provider-core": {
-      "version": "0.0.1-alpha.13",
-      "resolved": "https://registry.npmjs.org/@mongosh/service-provider-core/-/service-provider-core-0.0.1-alpha.13.tgz",
-      "integrity": "sha512-zoRQrG8PJIttWA8HJ+BGO7rZwWRcnCsSHawc6XObKK4gojCOEazlFpJmr9SRn8fW7JjJR6+PVxjHtl3vrbLkew==",
+      "version": "0.0.1-alpha.14",
+      "resolved": "https://registry.npmjs.org/@mongosh/service-provider-core/-/service-provider-core-0.0.1-alpha.14.tgz",
+      "integrity": "sha512-/kY/6wPM6/C6JprN3D48AUKUeRJVFc2geEyyABxNbyFfizHjtK4HhRzPylkTO/v8GIC3pY9tZRB6MGX+m4kcQw==",
       "dev": true
     },
     "@mongosh/service-provider-server": {
-      "version": "0.0.1-alpha.13",
-      "resolved": "https://registry.npmjs.org/@mongosh/service-provider-server/-/service-provider-server-0.0.1-alpha.13.tgz",
-      "integrity": "sha512-D6gfGt0W84yIweIjpNsxuFHbuFJd+74GtKkD1FS3puBnx2RU0Fx/H4y61n/Fnn+TqQwZ4tIjm6kPthqP6JhOjQ==",
+      "version": "0.0.1-alpha.14",
+      "resolved": "https://registry.npmjs.org/@mongosh/service-provider-server/-/service-provider-server-0.0.1-alpha.14.tgz",
+      "integrity": "sha512-gl3h6nXV6DsQa1JQNYmgub/5bR9GYIgL7+YSm5mUCOE6A1Xy92jKaoaJ624XSM9/6B6SnqULR63vEMVBMrnfJw==",
       "dev": true,
       "requires": {
-        "@mongosh/service-provider-core": "^0.0.1-alpha.13",
+        "@mongosh/service-provider-core": "^0.0.1-alpha.14",
         "mongodb": "3.5.3 || ^3.5.5"
       },
       "dependencies": {
@@ -2776,12 +2790,13 @@
       }
     },
     "@mongosh/shell-api": {
-      "version": "0.0.1-alpha.13",
-      "resolved": "https://registry.npmjs.org/@mongosh/shell-api/-/shell-api-0.0.1-alpha.13.tgz",
-      "integrity": "sha512-xzeCXMuNmVm6QceiP4Ynd6oNkCMD9yL16duNN8s0YQudocNi2ABzR9mebnQvqWijoaCr3RiypCGhJjq4CMhdVw==",
+      "version": "0.0.1-alpha.14",
+      "resolved": "https://registry.npmjs.org/@mongosh/shell-api/-/shell-api-0.0.1-alpha.14.tgz",
+      "integrity": "sha512-XoOEaQ8H7Wn4ZPYkIZeK0eWAHcwZSXyNkxkPDUM3ug7Jl7AgT6R0SLuYH0BhJtRcG4WlvUNGobJnL1EaWOjxMQ==",
       "dev": true,
       "requires": {
-        "@mongosh/i18n": "^0.0.1-alpha.13",
+        "@mongosh/errors": "^0.0.1-alpha.14",
+        "@mongosh/i18n": "^0.0.1-alpha.14",
         "bson": "^4.0.4"
       },
       "dependencies": {
@@ -2798,15 +2813,15 @@
       }
     },
     "@mongosh/shell-evaluator": {
-      "version": "0.0.1-alpha.13",
-      "resolved": "https://registry.npmjs.org/@mongosh/shell-evaluator/-/shell-evaluator-0.0.1-alpha.13.tgz",
-      "integrity": "sha512-Q4tZ1M4UXEbKP4RRkSz3ErtzzDstAiRKHtxs1ZQ1Idmd6FUfCL8WLMn2BQO1GnVl56BNaZpI/t9HnJvo8EHRAw==",
+      "version": "0.0.1-alpha.14",
+      "resolved": "https://registry.npmjs.org/@mongosh/shell-evaluator/-/shell-evaluator-0.0.1-alpha.14.tgz",
+      "integrity": "sha512-W75yM3NU/ymHLLjNC8lJugVdRli6L9rfDFKaiB3pRfLhcameXrLIcWfwqwAbqFf1B4dcVzsHp2luOgazsvkWPA==",
       "dev": true,
       "requires": {
-        "@mongosh/async-rewriter": "^0.0.1-alpha.13",
-        "@mongosh/mapper": "^0.0.1-alpha.13",
-        "@mongosh/service-provider-core": "^0.0.1-alpha.13",
-        "@mongosh/shell-api": "^0.0.1-alpha.13"
+        "@mongosh/async-rewriter": "^0.0.1-alpha.14",
+        "@mongosh/mapper": "^0.0.1-alpha.14",
+        "@mongosh/service-provider-core": "^0.0.1-alpha.14",
+        "@mongosh/shell-api": "^0.0.1-alpha.14"
       }
     },
     "@nodelib/fs.scandir": {
@@ -2833,6 +2848,16 @@
       "requires": {
         "@nodelib/fs.scandir": "2.1.3",
         "fastq": "^1.6.0"
+      }
+    },
+    "@segment/loosely-validate-event": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@segment/loosely-validate-event/-/loosely-validate-event-2.0.0.tgz",
+      "integrity": "sha512-ZMCSfztDBqwotkl848ODgVcAmN4OItEWDCkshcKz0/W6gGSQayuuCtWV/MlodFivAZD793d6UgANd6wCXUfrIw==",
+      "dev": true,
+      "requires": {
+        "component-type": "^1.2.1",
+        "join-component": "^1.1.0"
       }
     },
     "@sheerun/mutationobserver-shim": {
@@ -3045,9 +3070,9 @@
       }
     },
     "@types/yargs": {
-      "version": "13.0.8",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.8.tgz",
-      "integrity": "sha512-XAvHLwG7UQ+8M4caKIH0ZozIOYay5fQkAgyIXegXT9jPtdIGdhga+sUEdAr1CiG46aB+c64xQEYyEzlwWVTNzA==",
+      "version": "13.0.9",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.9.tgz",
+      "integrity": "sha512-xrvhZ4DZewMDhoH1utLtOAwYQy60eYFoXeje30TzM3VOvQlBwQaEpKFq5m34k1wOw2AKIi2pwtiAjdmhvlBUzg==",
       "dev": true,
       "requires": {
         "@types/yargs-parser": "*"
@@ -3323,6 +3348,15 @@
       "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
       "dev": true
     },
+    "acorn-class-fields": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-class-fields/-/acorn-class-fields-0.3.2.tgz",
+      "integrity": "sha512-wyqXoqzXSOF42uxHo40TMuC/KfloI66AZz6S1TeK8D2HjKzI7Boq1mSH2pB5RwKEJWgHqnewGpRFRZwR0qQCyQ==",
+      "dev": true,
+      "requires": {
+        "acorn-private-class-elements": "^0.2.5"
+      }
+    },
     "acorn-globals": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.4.tgz",
@@ -3364,6 +3398,36 @@
           "integrity": "sha512-4ufNLdC8gOf1dlOjC1nrn2NfzevyDtrDPp/DOtmoOHAFA/1pQc6bWf7oZ71qDURTODPLQ03+oFOvwxq5BvjXug==",
           "dev": true
         }
+      }
+    },
+    "acorn-numeric-separator": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-numeric-separator/-/acorn-numeric-separator-0.3.2.tgz",
+      "integrity": "sha512-ZNN1qnKvjWycDSQBfuD1TCiB81ItjjeGUPLHuqfP8X8HXwAodGTWsAaqSOQ1Nc9t+Wlb3tcEFdBrwUFUIzDiiA==",
+      "dev": true
+    },
+    "acorn-private-class-elements": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/acorn-private-class-elements/-/acorn-private-class-elements-0.2.5.tgz",
+      "integrity": "sha512-3eApRrJmPjaxWB3XidP8YMeVq9pcswPFE0KsSWVuhceCU68ZS8fkcf0fTXGhCmnNd7n48NWWV27EKMFPeCoJLg==",
+      "dev": true
+    },
+    "acorn-private-methods": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/acorn-private-methods/-/acorn-private-methods-0.3.1.tgz",
+      "integrity": "sha512-IV5XZInFQaQK5ucjJy/HAk2UYvt+Buax00evzwo8NSuo8zhOBhW5v6VOjAljYUhAzQ/Hosi+Kaz6xJmvPiSM4Q==",
+      "dev": true,
+      "requires": {
+        "acorn-private-class-elements": "^0.2.4"
+      }
+    },
+    "acorn-static-class-features": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/acorn-static-class-features/-/acorn-static-class-features-0.2.1.tgz",
+      "integrity": "sha512-eLIAEBFwu1bcZD+39u5PAcAargtkI5tY1uDRQV6SB3zY4JIO0vqvSdtZ8hz1GGZIVY/d3RDxkM9BLTPTNNVwGw==",
+      "dev": true,
+      "requires": {
+        "acorn-private-class-elements": "^0.2.3"
       }
     },
     "acorn-walk": {
@@ -3623,6 +3687,30 @@
       "requires": {
         "find-root": "^0.1.1",
         "through2": "^0.6.3"
+      }
+    },
+    "analytics-node": {
+      "version": "3.4.0-beta.1",
+      "resolved": "https://registry.npmjs.org/analytics-node/-/analytics-node-3.4.0-beta.1.tgz",
+      "integrity": "sha512-+0F/y4Asc5S2qhWcYss+iCob6TTXQktwbqlIk02gcZaRxpekCbnTbJu/rcaRooVHxqp9WSzUXiWCesJYPJETZQ==",
+      "dev": true,
+      "requires": {
+        "@segment/loosely-validate-event": "^2.0.0",
+        "axios": "^0.18.1",
+        "axios-retry": "^3.0.2",
+        "lodash.isstring": "^4.0.1",
+        "md5": "^2.2.1",
+        "ms": "^2.0.0",
+        "remove-trailing-slash": "^0.1.0",
+        "uuid": "^3.2.1"
+      },
+      "dependencies": {
+        "lodash.isstring": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+          "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
+          "dev": true
+        }
       }
     },
     "ansi": {
@@ -4097,6 +4185,57 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
       "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==",
       "dev": true
+    },
+    "axios": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
+      "integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
+      "dev": true,
+      "requires": {
+        "follow-redirects": "1.5.10",
+        "is-buffer": "^2.0.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.5.10",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+          "dev": true,
+          "requires": {
+            "debug": "=3.1.0"
+          }
+        },
+        "is-buffer": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "axios-retry": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.1.8.tgz",
+      "integrity": "sha512-yPw5Y4Bg6Dgmhm35KaJFtlh23s1TecW0HsUerK4/IS1UKl0gtN2aJqdEKtVomiOS/bDo5w4P3sqgki/M10eF8Q==",
+      "dev": true,
+      "requires": {
+        "is-retry-allowed": "^1.1.0"
+      }
     },
     "babel-cli": {
       "version": "6.26.0",
@@ -6361,6 +6500,12 @@
         }
       }
     },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=",
+      "dev": true
+    },
     "check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
@@ -6819,6 +6964,12 @@
       "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=",
       "dev": true
     },
+    "component-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/component-type/-/component-type-1.2.1.tgz",
+      "integrity": "sha1-ikeQFwAjjk/DIml3EjAibyS0Fak=",
+      "dev": true
+    },
     "compressible": {
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
@@ -7229,6 +7380,12 @@
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
       }
+    },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=",
+      "dev": true
     },
     "cryptiles": {
       "version": "2.0.5",
@@ -13294,6 +13451,27 @@
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
     },
+    "is-recoverable-error": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-recoverable-error/-/is-recoverable-error-1.0.1.tgz",
+      "integrity": "sha512-1v/3hIRd0hHzkmq9TU+otd8SlUJjr60KyX6RfgwJ6NVbeQafc3POajWZ/BcusPxhdX0ScN3xE9tTnn6xGpC3LA==",
+      "dev": true,
+      "requires": {
+        "acorn": "^7.1.1",
+        "acorn-class-fields": "^0.3.2",
+        "acorn-numeric-separator": "^0.3.1",
+        "acorn-private-methods": "^0.3.1",
+        "acorn-static-class-features": "^0.2.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.2.0.tgz",
+          "integrity": "sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ==",
+          "dev": true
+        }
+      }
+    },
     "is-regex": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
@@ -13311,6 +13489,12 @@
       "requires": {
         "is-unc-path": "^1.0.0"
       }
+    },
+    "is-retry-allowed": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
+      "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
+      "dev": true
     },
     "is-stream": {
       "version": "1.1.0",
@@ -13720,6 +13904,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/javascript-stringify/-/javascript-stringify-2.0.1.tgz",
       "integrity": "sha512-yV+gqbd5vaOYjqlbk16EG89xB5udgjqQF3C5FAORDg4f/IS1Yc5ERCv5e/57yBcfJYw05V5JyIXabhwb75Xxow==",
+      "dev": true
+    },
+    "join-component": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/join-component/-/join-component-1.1.0.tgz",
+      "integrity": "sha1-uEF7dQZho5K+4sJTfGiyqdSXfNU=",
       "dev": true
     },
     "js-base64": {
@@ -16213,6 +16403,17 @@
       "integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A==",
       "dev": true,
       "optional": true
+    },
+    "md5": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
+      "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
+      "dev": true,
+      "requires": {
+        "charenc": "~0.0.1",
+        "crypt": "~0.0.1",
+        "is-buffer": "~1.1.1"
+      }
     },
     "md5.js": {
       "version": "1.3.5",
@@ -22984,6 +23185,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "dev": true
+    },
+    "remove-trailing-slash": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-slash/-/remove-trailing-slash-0.1.0.tgz",
+      "integrity": "sha1-FJjl3wmEwn5Jt26/Boh8otARUNI=",
       "dev": true
     },
     "renderkid": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,6 +76,50 @@
         }
       }
     },
+    "@babel/helper-create-class-features-plugin": {
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.9.6.tgz",
+      "integrity": "sha512-6N9IeuyHvMBRyjNYOMJHrhwtu4WJMrYf8hVbEHD3pbbbmNOk1kmXSQs7bA4dYDUaIx4ZEzdnvo6NwC3WHd/Qow==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.9.5",
+        "@babel/helper-member-expression-to-functions": "^7.8.3",
+        "@babel/helper-optimise-call-expression": "^7.8.3",
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/helper-replace-supers": "^7.9.6",
+        "@babel/helper-split-export-declaration": "^7.8.3"
+      },
+      "dependencies": {
+        "@babel/helper-function-name": {
+          "version": "7.9.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.9.5.tgz",
+          "integrity": "sha512-JVcQZeXM59Cd1qanDUxv9fgJpt3NeKUaqBqUEvfmQ+BCOKq2xUgaWZW2hr0dkbyJgezYuplEoh5knmrnS68efw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.8.3",
+            "@babel/template": "^7.8.3",
+            "@babel/types": "^7.9.5"
+          }
+        },
+        "@babel/types": {
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.6.tgz",
+          "integrity": "sha512-qxXzvBO//jO9ZnoasKF1uJzHd2+M6Q2ZPIVfnFps8JJvXy0ZBbwbNOmE6SGIY5XOY6d1Bo5lb9d9RJ8nv3WSeA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.9.5",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+          "dev": true
+        }
+      }
+    },
     "@babel/helper-function-name": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
@@ -96,6 +140,198 @@
         "@babel/types": "^7.8.3"
       }
     },
+    "@babel/helper-member-expression-to-functions": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.8.3.tgz",
+      "integrity": "sha512-fO4Egq88utkQFjbPrSHGmGLFqmrshs11d46WI+WZDESt7Wu7wN2G2Iu+NMMZJFDOVRHAMIkB5SNh30NtwCA7RA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.8.3"
+      }
+    },
+    "@babel/helper-module-imports": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.8.3.tgz",
+      "integrity": "sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.8.3"
+      }
+    },
+    "@babel/helper-module-transforms": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.9.0.tgz",
+      "integrity": "sha512-0FvKyu0gpPfIQ8EkxlrAydOWROdHpBmiCiRwLkUiBGhCUPRRbVD2/tm3sFr/c/GWFrQ/ffutGUAnx7V0FzT2wA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.8.3",
+        "@babel/helper-replace-supers": "^7.8.6",
+        "@babel/helper-simple-access": "^7.8.3",
+        "@babel/helper-split-export-declaration": "^7.8.3",
+        "@babel/template": "^7.8.6",
+        "@babel/types": "^7.9.0",
+        "lodash": "^4.17.13"
+      },
+      "dependencies": {
+        "@babel/parser": {
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.6.tgz",
+          "integrity": "sha512-AoeIEJn8vt+d/6+PXDRPaksYhnlbMIiejioBZvvMQsOjW/JYK6k/0dKnvvP3EhK5GfMBWDPtrxRtegWdAcdq9Q==",
+          "dev": true
+        },
+        "@babel/template": {
+          "version": "7.8.6",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
+          "integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@babel/parser": "^7.8.6",
+            "@babel/types": "^7.8.6"
+          }
+        },
+        "@babel/types": {
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.6.tgz",
+          "integrity": "sha512-qxXzvBO//jO9ZnoasKF1uJzHd2+M6Q2ZPIVfnFps8JJvXy0ZBbwbNOmE6SGIY5XOY6d1Bo5lb9d9RJ8nv3WSeA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.9.5",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-optimise-call-expression": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.8.3.tgz",
+      "integrity": "sha512-Kag20n86cbO2AvHca6EJsvqAd82gc6VMGule4HwebwMlwkpXuVqrNRj6CkCV2sKxgi9MyAUnZVnZ6lJ1/vKhHQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.8.3"
+      }
+    },
+    "@babel/helper-plugin-utils": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
+      "integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
+      "dev": true
+    },
+    "@babel/helper-replace-supers": {
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.9.6.tgz",
+      "integrity": "sha512-qX+chbxkbArLyCImk3bWV+jB5gTNU/rsze+JlcF6Nf8tVTigPJSI1o1oBow/9Resa1yehUO9lIipsmu9oG4RzA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-member-expression-to-functions": "^7.8.3",
+        "@babel/helper-optimise-call-expression": "^7.8.3",
+        "@babel/traverse": "^7.9.6",
+        "@babel/types": "^7.9.6"
+      },
+      "dependencies": {
+        "@babel/generator": {
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.6.tgz",
+          "integrity": "sha512-+htwWKJbH2bL72HRluF8zumBxzuX0ZZUFl3JLNyoUjM/Ho8wnVpPXM6aUz8cfKDqQ/h7zHqKt4xzJteUosckqQ==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.9.6",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.13",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.9.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.9.5.tgz",
+          "integrity": "sha512-JVcQZeXM59Cd1qanDUxv9fgJpt3NeKUaqBqUEvfmQ+BCOKq2xUgaWZW2hr0dkbyJgezYuplEoh5knmrnS68efw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.8.3",
+            "@babel/template": "^7.8.3",
+            "@babel/types": "^7.9.5"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.6.tgz",
+          "integrity": "sha512-AoeIEJn8vt+d/6+PXDRPaksYhnlbMIiejioBZvvMQsOjW/JYK6k/0dKnvvP3EhK5GfMBWDPtrxRtegWdAcdq9Q==",
+          "dev": true
+        },
+        "@babel/traverse": {
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.6.tgz",
+          "integrity": "sha512-b3rAHSjbxy6VEAvlxM8OV/0X4XrG72zoxme6q1MOoe2vd0bEc+TwayhuC1+Dfgqh1QEG+pj7atQqvUprHIccsg==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@babel/generator": "^7.9.6",
+            "@babel/helper-function-name": "^7.9.5",
+            "@babel/helper-split-export-declaration": "^7.8.3",
+            "@babel/parser": "^7.9.6",
+            "@babel/types": "^7.9.6",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.13"
+          }
+        },
+        "@babel/types": {
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.6.tgz",
+          "integrity": "sha512-qxXzvBO//jO9ZnoasKF1uJzHd2+M6Q2ZPIVfnFps8JJvXy0ZBbwbNOmE6SGIY5XOY6d1Bo5lb9d9RJ8nv3WSeA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.9.5",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "globals": {
+          "version": "11.12.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+          "dev": true
+        },
+        "jsesc": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+          "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+          "dev": true
+        },
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-simple-access": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.8.3.tgz",
+      "integrity": "sha512-VNGUDjx5cCWg4vvCTR8qQ7YJYZ+HBjxOgXEl7ounz+4Sn7+LMD3CFrCTEU6/qXKbA2nKg21CwhhBzO0RpRbdCw==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.8.3",
+        "@babel/types": "^7.8.3"
+      }
+    },
     "@babel/helper-split-export-declaration": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
@@ -104,6 +340,12 @@
       "requires": {
         "@babel/types": "^7.8.3"
       }
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.9.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
+      "integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g==",
+      "dev": true
     },
     "@babel/helpers": {
       "version": "7.8.4",
@@ -140,6 +382,36 @@
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.4.tgz",
       "integrity": "sha512-0fKu/QqildpXmPVaRBoXOlyBb3MC+J0A66x97qEfLOMkn3u6nfY5esWogQwi/K0BjASYy4DbnsEWnpNL6qT5Mw==",
       "dev": true
+    },
+    "@babel/plugin-syntax-typescript": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.8.3.tgz",
+      "integrity": "sha512-GO1MQ/SGGGoiEXY0e0bSpHimJvxqB7lktLLIq2pv8xG7WZ8IMEle74jIe1FhprHBWjwjZtXHkycDLZXIWM5Wfg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-typescript": {
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.9.6.tgz",
+      "integrity": "sha512-8OvsRdvpt3Iesf2qsAn+YdlwAJD7zJ+vhFZmDCa4b8dTp7MmHtKk5FF2mCsGxjZwuwsy/yIIay/nLmxST1ctVQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.9.6",
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/plugin-syntax-typescript": "^7.8.3"
+      }
+    },
+    "@babel/preset-typescript": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.9.0.tgz",
+      "integrity": "sha512-S4cueFnGrIbvYJgwsVFKdvOmpiL0XGw9MFW9D0vgRys5g36PBhZRL8NX8Gr2akz8XRtzq6HuDXPD/1nniagNUg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/plugin-transform-typescript": "^7.9.0"
+      }
     },
     "@babel/runtime": {
       "version": "7.8.4",
@@ -240,6 +512,73 @@
         }
       }
     },
+    "@emotion/cache": {
+      "version": "10.0.29",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.29.tgz",
+      "integrity": "sha512-fU2VtSVlHiF27empSbxi1O2JFdNWZO+2NFHfwO0pxgTep6Xa3uGb+3pVKfLww2l/IBGLNEZl5Xf/++A4wAYDYQ==",
+      "dev": true,
+      "requires": {
+        "@emotion/sheet": "0.9.4",
+        "@emotion/stylis": "0.8.5",
+        "@emotion/utils": "0.11.3",
+        "@emotion/weak-memoize": "0.2.5"
+      }
+    },
+    "@emotion/hash": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
+      "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==",
+      "dev": true
+    },
+    "@emotion/memoize": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
+      "dev": true
+    },
+    "@emotion/serialize": {
+      "version": "0.11.16",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.16.tgz",
+      "integrity": "sha512-G3J4o8by0VRrO+PFeSc3js2myYNOXVJ3Ya+RGVxnshRYgsvErfAOglKAiy1Eo1vhzxqtUvjCyS5gtewzkmvSSg==",
+      "dev": true,
+      "requires": {
+        "@emotion/hash": "0.8.0",
+        "@emotion/memoize": "0.7.4",
+        "@emotion/unitless": "0.7.5",
+        "@emotion/utils": "0.11.3",
+        "csstype": "^2.5.7"
+      }
+    },
+    "@emotion/sheet": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.4.tgz",
+      "integrity": "sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA==",
+      "dev": true
+    },
+    "@emotion/stylis": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
+      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==",
+      "dev": true
+    },
+    "@emotion/unitless": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
+      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==",
+      "dev": true
+    },
+    "@emotion/utils": {
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
+      "integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw==",
+      "dev": true
+    },
+    "@emotion/weak-memoize": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
+      "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==",
+      "dev": true
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz",
@@ -265,6 +604,64 @@
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.2.tgz",
       "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
       "dev": true
+    },
+    "@jest/types": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
+      "integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^1.1.1",
+        "@types/yargs": "^13.0.0"
+      }
+    },
+    "@leafygreen-ui/emotion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/emotion/-/emotion-2.0.1.tgz",
+      "integrity": "sha512-eswO+aWs6vbuiEDUpZz3tGjCBtgWr3hU4ndgrjFLNOQpWOsVOaW8zQzVu1XOMLHCjtfZy2/GDME7zQWVvcrVFg==",
+      "dev": true,
+      "requires": {
+        "create-emotion": "^10.0.7",
+        "create-emotion-server": "10.0.27",
+        "emotion": "^10.0.7"
+      }
+    },
+    "@leafygreen-ui/icon": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-4.3.0.tgz",
+      "integrity": "sha512-6DOFKxj3U0hp2yQEq/Yq19qIiIIUXwRj2fH1ddOJFYLtAoeFOCSeuF6rE2dqXrXW/puQdjgpXV60w9J8gyXGog==",
+      "dev": true
+    },
+    "@leafygreen-ui/lib": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-4.4.1.tgz",
+      "integrity": "sha512-ZVa/LlcoWBXLpks5XQ6MsM/f3cMqxxsqD8iQlGkGncJZN8cJ7NnxqtyY7QsbGSHNQzSNJbOtHxg6dpYRuAWcPw==",
+      "dev": true,
+      "requires": {
+        "@leafygreen-ui/emotion": "^2.0.1",
+        "@testing-library/react": "^8.0.1",
+        "facepaint": "^1.2.1",
+        "polished": "^2.3.0"
+      }
+    },
+    "@leafygreen-ui/palette": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-2.0.1.tgz",
+      "integrity": "sha512-xwD6kOokWvaygxF0T2gnf77HEu68G7EXr1ZrNiNtZzg80Y1V2hikhUNoESWij6g/A6qJZvAiwpseflVo3PnlHQ==",
+      "dev": true
+    },
+    "@leafygreen-ui/syntax": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/syntax/-/syntax-2.7.0.tgz",
+      "integrity": "sha512-bQRIFKPUwZsne39R49eQN5qEl556w88N/FjJfzAU/LjR2OVp+W5sWhx1PiacwCq+J1r/7wu/PKUh5rV/dpSgmQ==",
+      "dev": true,
+      "requires": {
+        "@leafygreen-ui/lib": "^4.3.0",
+        "@leafygreen-ui/palette": "^2.0.1",
+        "highlight.js": "^9.15.6",
+        "highlightjs-graphql": "^1.0.1"
+      }
     },
     "@mongodb-js/compass-aggregations": {
       "version": "2.2.18",
@@ -1867,6 +2264,17 @@
         }
       }
     },
+    "@mongodb-js/compass-shell": {
+      "version": "0.0.1-alpha.13",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-shell/-/compass-shell-0.0.1-alpha.13.tgz",
+      "integrity": "sha512-vKBKRGU+sDAOU2oXMWtcDd5QA6qRJ/tzvsw85R2YL5BDOvrFDBqpT7B79MqQRKXWG76oBRnzaoGwPaMd41SiOQ==",
+      "dev": true,
+      "requires": {
+        "@mongosh/browser-repl": "^0.0.1-alpha.13",
+        "@mongosh/browser-runtime-electron": "^0.0.1-alpha.13",
+        "@mongosh/service-provider-server": "^0.0.1-alpha.13"
+      }
+    },
     "@mongodb-js/compass-sidebar": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/@mongodb-js/compass-sidebar/-/compass-sidebar-0.0.7.tgz",
@@ -1897,6 +2305,510 @@
         }
       }
     },
+    "@mongosh/async-rewriter": {
+      "version": "0.0.1-alpha.13",
+      "resolved": "https://registry.npmjs.org/@mongosh/async-rewriter/-/async-rewriter-0.0.1-alpha.13.tgz",
+      "integrity": "sha512-fpgz00RK2440Nh/FygNYcaMzX7DAN2nDhzQO6PoFUklMvB66IjVjuPmM+eNCb4qMc46oZYsz8PgeNo6lu/JCRg==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.9.0",
+        "@babel/parser": "^7.9.4",
+        "@babel/preset-typescript": "^7.9.0",
+        "@babel/template": "^7.8.6",
+        "@babel/traverse": "^7.9.0",
+        "@babel/types": "^7.9.0",
+        "@mongosh/errors": "^0.0.1-alpha.13",
+        "@types/babel__core": "^7.1.6",
+        "@types/babel__traverse": "^7.0.9",
+        "ts-node": "^8.8.1",
+        "typescript": "^3.8.3"
+      },
+      "dependencies": {
+        "@babel/core": {
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.9.6.tgz",
+          "integrity": "sha512-nD3deLvbsApbHAHttzIssYqgb883yU/d9roe4RZymBCDaZryMJDbptVpEpeQuRh4BJ+SYI8le9YGxKvFEvl1Wg==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@babel/generator": "^7.9.6",
+            "@babel/helper-module-transforms": "^7.9.0",
+            "@babel/helpers": "^7.9.6",
+            "@babel/parser": "^7.9.6",
+            "@babel/template": "^7.8.6",
+            "@babel/traverse": "^7.9.6",
+            "@babel/types": "^7.9.6",
+            "convert-source-map": "^1.7.0",
+            "debug": "^4.1.0",
+            "gensync": "^1.0.0-beta.1",
+            "json5": "^2.1.2",
+            "lodash": "^4.17.13",
+            "resolve": "^1.3.2",
+            "semver": "^5.4.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.6.tgz",
+          "integrity": "sha512-+htwWKJbH2bL72HRluF8zumBxzuX0ZZUFl3JLNyoUjM/Ho8wnVpPXM6aUz8cfKDqQ/h7zHqKt4xzJteUosckqQ==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.9.6",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.13",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.9.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.9.5.tgz",
+          "integrity": "sha512-JVcQZeXM59Cd1qanDUxv9fgJpt3NeKUaqBqUEvfmQ+BCOKq2xUgaWZW2hr0dkbyJgezYuplEoh5knmrnS68efw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.8.3",
+            "@babel/template": "^7.8.3",
+            "@babel/types": "^7.9.5"
+          }
+        },
+        "@babel/helpers": {
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.9.6.tgz",
+          "integrity": "sha512-tI4bUbldloLcHWoRUMAj4g1bF313M/o6fBKhIsb3QnGVPwRm9JsNf/gqMkQ7zjqReABiffPV6RWj7hEglID5Iw==",
+          "dev": true,
+          "requires": {
+            "@babel/template": "^7.8.3",
+            "@babel/traverse": "^7.9.6",
+            "@babel/types": "^7.9.6"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.6.tgz",
+          "integrity": "sha512-AoeIEJn8vt+d/6+PXDRPaksYhnlbMIiejioBZvvMQsOjW/JYK6k/0dKnvvP3EhK5GfMBWDPtrxRtegWdAcdq9Q==",
+          "dev": true
+        },
+        "@babel/template": {
+          "version": "7.8.6",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
+          "integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@babel/parser": "^7.8.6",
+            "@babel/types": "^7.8.6"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.6.tgz",
+          "integrity": "sha512-b3rAHSjbxy6VEAvlxM8OV/0X4XrG72zoxme6q1MOoe2vd0bEc+TwayhuC1+Dfgqh1QEG+pj7atQqvUprHIccsg==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@babel/generator": "^7.9.6",
+            "@babel/helper-function-name": "^7.9.5",
+            "@babel/helper-split-export-declaration": "^7.8.3",
+            "@babel/parser": "^7.9.6",
+            "@babel/types": "^7.9.6",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.13"
+          }
+        },
+        "@babel/types": {
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.6.tgz",
+          "integrity": "sha512-qxXzvBO//jO9ZnoasKF1uJzHd2+M6Q2ZPIVfnFps8JJvXy0ZBbwbNOmE6SGIY5XOY6d1Bo5lb9d9RJ8nv3WSeA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.9.5",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "globals": {
+          "version": "11.12.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+          "dev": true
+        },
+        "jsesc": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+          "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+          "dev": true
+        },
+        "json5": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+          "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        },
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+          "dev": true
+        },
+        "typescript": {
+          "version": "3.8.3",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+          "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+          "dev": true
+        }
+      }
+    },
+    "@mongosh/browser-repl": {
+      "version": "0.0.1-alpha.13",
+      "resolved": "https://registry.npmjs.org/@mongosh/browser-repl/-/browser-repl-0.0.1-alpha.13.tgz",
+      "integrity": "sha512-eXGHMFhdDZ7Qs3+iadNOYk07eoPUg6vCDBGcCWq3vYWmKRWfYJpXSU83EhdQp4XK2FTbaNwuiat56M3TPCh9Uw==",
+      "dev": true,
+      "requires": {
+        "@babel/generator": "^7.8.3",
+        "@babel/parser": "^7.8.3",
+        "@babel/runtime": "^7.8.3",
+        "@babel/template": "^7.8.3",
+        "@leafygreen-ui/icon": "^4.0.0",
+        "@leafygreen-ui/palette": "^2.0.0",
+        "@leafygreen-ui/syntax": "^2.2.0",
+        "@mongosh/browser-runtime-core": "^0.0.1-alpha.13",
+        "@mongosh/history": "^0.0.1-alpha.13",
+        "@mongosh/i18n": "^0.0.1-alpha.13",
+        "@mongosh/service-provider-core": "^0.0.1-alpha.13",
+        "pretty-bytes": "^5.3.0",
+        "text-table": "^0.2.0"
+      },
+      "dependencies": {
+        "pretty-bytes": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.3.0.tgz",
+          "integrity": "sha512-hjGrh+P926p4R4WbaB6OckyRtO0F0/lQBiT+0gnxjV+5kjPBrfVBFCsCLbMqVQeydvIoouYTCmmEURiH3R1Bdg==",
+          "dev": true
+        }
+      }
+    },
+    "@mongosh/browser-runtime-core": {
+      "version": "0.0.1-alpha.13",
+      "resolved": "https://registry.npmjs.org/@mongosh/browser-runtime-core/-/browser-runtime-core-0.0.1-alpha.13.tgz",
+      "integrity": "sha512-K0p0U25utbzfF6ejk4x55YEsq9NoBrZ/V3PFnjniBuLbmGCoLu3ByUR25gbuNastnQvjt59sro4OkQrEFlbzVw==",
+      "dev": true,
+      "requires": {
+        "@babel/generator": "^7.9.4",
+        "@babel/parser": "^7.9.4",
+        "@mongosh/cli-repl": "^0.0.1-alpha.13",
+        "@mongosh/service-provider-core": "^0.0.1-alpha.13",
+        "@mongosh/shell-evaluator": "^0.0.1-alpha.13"
+      },
+      "dependencies": {
+        "@babel/generator": {
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.6.tgz",
+          "integrity": "sha512-+htwWKJbH2bL72HRluF8zumBxzuX0ZZUFl3JLNyoUjM/Ho8wnVpPXM6aUz8cfKDqQ/h7zHqKt4xzJteUosckqQ==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.9.6",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.13",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.6.tgz",
+          "integrity": "sha512-AoeIEJn8vt+d/6+PXDRPaksYhnlbMIiejioBZvvMQsOjW/JYK6k/0dKnvvP3EhK5GfMBWDPtrxRtegWdAcdq9Q==",
+          "dev": true
+        },
+        "@babel/types": {
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.6.tgz",
+          "integrity": "sha512-qxXzvBO//jO9ZnoasKF1uJzHd2+M6Q2ZPIVfnFps8JJvXy0ZBbwbNOmE6SGIY5XOY6d1Bo5lb9d9RJ8nv3WSeA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.9.5",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "jsesc": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+          "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+          "dev": true
+        },
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+          "dev": true
+        }
+      }
+    },
+    "@mongosh/browser-runtime-electron": {
+      "version": "0.0.1-alpha.13",
+      "resolved": "https://registry.npmjs.org/@mongosh/browser-runtime-electron/-/browser-runtime-electron-0.0.1-alpha.13.tgz",
+      "integrity": "sha512-saGjydRsCE43bAY1pMzEaKZFS70oz+CPCZSLhwYrE6bzdzhfPXN7HDJCUzws5wg1waAEh+rRqRq0UnxT0c/rgw==",
+      "dev": true,
+      "requires": {
+        "@mongosh/browser-runtime-core": "^0.0.1-alpha.13",
+        "@mongosh/service-provider-core": "^0.0.1-alpha.13"
+      }
+    },
+    "@mongosh/cli-repl": {
+      "version": "0.0.1-alpha.13",
+      "resolved": "https://registry.npmjs.org/@mongosh/cli-repl/-/cli-repl-0.0.1-alpha.13.tgz",
+      "integrity": "sha512-IBUXC46rDBBexctccJ64f4R7zTI5oeqN9AW/sym/F1kyZJK2p7VeRlsCgrLwyg70VZVdAGCkOt88kmPCxirJnQ==",
+      "dev": true,
+      "requires": {
+        "@mongosh/history": "^0.0.1-alpha.13",
+        "@mongosh/i18n": "^0.0.1-alpha.13",
+        "@mongosh/service-provider-server": "^0.0.1-alpha.13",
+        "@mongosh/shell-api": "^0.0.1-alpha.13",
+        "@mongosh/shell-evaluator": "^0.0.1-alpha.13",
+        "ansi-escape-sequences": "^5.1.2",
+        "bson": "^4.0.4",
+        "lodash.set": "^4.3.2",
+        "minimist": "^1.2.5",
+        "mkdirp": "^1.0.3",
+        "mongodb-ace-autocompleter": "^0.4.1",
+        "mongodb-build-info": "^1.0.0",
+        "mongodb-redact": "^0.2.0",
+        "nanobus": "^4.4.0",
+        "pino": "^5.16.0",
+        "pretty-bytes": "^5.3.0",
+        "pretty-repl": "^2.3.0",
+        "read": "^1.0.7",
+        "semver": "^7.1.2",
+        "text-table": "^0.2.0"
+      },
+      "dependencies": {
+        "bson": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-4.0.4.tgz",
+          "integrity": "sha512-Ioi3TD0/1V3aI8+hPfC56TetYmzfq2H07jJa9A1lKTxWsFtHtYdLMGMXjtGEg9v0f72NSM07diRQEUNYhLupIA==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.1.0",
+            "long": "^4.0.0"
+          }
+        },
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true
+        },
+        "pretty-bytes": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.3.0.tgz",
+          "integrity": "sha512-hjGrh+P926p4R4WbaB6OckyRtO0F0/lQBiT+0gnxjV+5kjPBrfVBFCsCLbMqVQeydvIoouYTCmmEURiH3R1Bdg==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+          "dev": true
+        }
+      }
+    },
+    "@mongosh/errors": {
+      "version": "0.0.1-alpha.13",
+      "resolved": "https://registry.npmjs.org/@mongosh/errors/-/errors-0.0.1-alpha.13.tgz",
+      "integrity": "sha512-jJ5s2lpszODjYm8FH7+zhf2tAXTFnsUMchdUYlIxfcodr3QzQJNxySrmj0C9jwddwvFQ5zzxkJDtA4EUcF+YaA==",
+      "dev": true
+    },
+    "@mongosh/history": {
+      "version": "0.0.1-alpha.13",
+      "resolved": "https://registry.npmjs.org/@mongosh/history/-/history-0.0.1-alpha.13.tgz",
+      "integrity": "sha512-qZjTKYxmP8VsPTXVWpaVpyPQTcJo7UrcOnN1uvPtmLXJ6s6yny7rSFYi+QPqahheShrb062YjnNGyUSdI/qSEw==",
+      "dev": true,
+      "requires": {
+        "mongodb-redact": "^0.2.0"
+      }
+    },
+    "@mongosh/i18n": {
+      "version": "0.0.1-alpha.13",
+      "resolved": "https://registry.npmjs.org/@mongosh/i18n/-/i18n-0.0.1-alpha.13.tgz",
+      "integrity": "sha512-afSXLbzsW+F9zbeN0T1cc6VwmDrOjr5qQzF+r5KYvz6Z3tbkJf6uxct9m6YicNy2qxnGKDQtQ2lMdtmFXV5Ptw==",
+      "dev": true,
+      "requires": {
+        "mustache": "^4.0.0"
+      }
+    },
+    "@mongosh/mapper": {
+      "version": "0.0.1-alpha.13",
+      "resolved": "https://registry.npmjs.org/@mongosh/mapper/-/mapper-0.0.1-alpha.13.tgz",
+      "integrity": "sha512-UHT7jpH5bVBkJFXn27H7R9/PjOh0O4DWT1Mog47ib9PXZAf2fy2GtSWWV8Zmamjg2ewBJv5vLd9VAqMyqCnruA==",
+      "dev": true,
+      "requires": {
+        "@mongosh/errors": "^0.0.1-alpha.13",
+        "@mongosh/service-provider-core": "^0.0.1-alpha.13",
+        "@mongosh/shell-api": "^0.0.1-alpha.13",
+        "pretty-bytes": "^5.3.0",
+        "text-table": "^0.2.0"
+      },
+      "dependencies": {
+        "pretty-bytes": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.3.0.tgz",
+          "integrity": "sha512-hjGrh+P926p4R4WbaB6OckyRtO0F0/lQBiT+0gnxjV+5kjPBrfVBFCsCLbMqVQeydvIoouYTCmmEURiH3R1Bdg==",
+          "dev": true
+        }
+      }
+    },
+    "@mongosh/service-provider-core": {
+      "version": "0.0.1-alpha.13",
+      "resolved": "https://registry.npmjs.org/@mongosh/service-provider-core/-/service-provider-core-0.0.1-alpha.13.tgz",
+      "integrity": "sha512-zoRQrG8PJIttWA8HJ+BGO7rZwWRcnCsSHawc6XObKK4gojCOEazlFpJmr9SRn8fW7JjJR6+PVxjHtl3vrbLkew==",
+      "dev": true
+    },
+    "@mongosh/service-provider-server": {
+      "version": "0.0.1-alpha.13",
+      "resolved": "https://registry.npmjs.org/@mongosh/service-provider-server/-/service-provider-server-0.0.1-alpha.13.tgz",
+      "integrity": "sha512-D6gfGt0W84yIweIjpNsxuFHbuFJd+74GtKkD1FS3puBnx2RU0Fx/H4y61n/Fnn+TqQwZ4tIjm6kPthqP6JhOjQ==",
+      "dev": true,
+      "requires": {
+        "@mongosh/service-provider-core": "^0.0.1-alpha.13",
+        "mongodb": "3.5.3 || ^3.5.5"
+      },
+      "dependencies": {
+        "bl": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.0.tgz",
+          "integrity": "sha512-wbgvOpqopSr7uq6fJrLH8EsvYMJf9gzfo2jCsL2eTy75qXPukA4pCgHamOQkZtY5vmfVtjB+P3LNlMHW5CEZXA==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "^2.3.5",
+            "safe-buffer": "^5.1.1"
+          }
+        },
+        "bson": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.4.tgz",
+          "integrity": "sha512-S/yKGU1syOMzO86+dGpg2qGoDL0zvzcb262G+gqEy6TgP6rt6z6qxSFX/8X6vLC91P7G7C3nLs0+bvDzmvBA3Q==",
+          "dev": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "mongodb": {
+          "version": "3.5.7",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.5.7.tgz",
+          "integrity": "sha512-lMtleRT+vIgY/JhhTn1nyGwnSMmJkJELp+4ZbrjctrnBxuLbj6rmLuJFz8W2xUzUqWmqoyVxJLYuC58ZKpcTYQ==",
+          "dev": true,
+          "requires": {
+            "bl": "^2.2.0",
+            "bson": "^1.1.4",
+            "denque": "^1.4.1",
+            "require_optional": "^1.0.1",
+            "safe-buffer": "^5.1.2",
+            "saslprep": "^1.0.0"
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+              "dev": true
+            }
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
+    "@mongosh/shell-api": {
+      "version": "0.0.1-alpha.13",
+      "resolved": "https://registry.npmjs.org/@mongosh/shell-api/-/shell-api-0.0.1-alpha.13.tgz",
+      "integrity": "sha512-xzeCXMuNmVm6QceiP4Ynd6oNkCMD9yL16duNN8s0YQudocNi2ABzR9mebnQvqWijoaCr3RiypCGhJjq4CMhdVw==",
+      "dev": true,
+      "requires": {
+        "@mongosh/i18n": "^0.0.1-alpha.13",
+        "bson": "^4.0.4"
+      },
+      "dependencies": {
+        "bson": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-4.0.4.tgz",
+          "integrity": "sha512-Ioi3TD0/1V3aI8+hPfC56TetYmzfq2H07jJa9A1lKTxWsFtHtYdLMGMXjtGEg9v0f72NSM07diRQEUNYhLupIA==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.1.0",
+            "long": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@mongosh/shell-evaluator": {
+      "version": "0.0.1-alpha.13",
+      "resolved": "https://registry.npmjs.org/@mongosh/shell-evaluator/-/shell-evaluator-0.0.1-alpha.13.tgz",
+      "integrity": "sha512-Q4tZ1M4UXEbKP4RRkSz3ErtzzDstAiRKHtxs1ZQ1Idmd6FUfCL8WLMn2BQO1GnVl56BNaZpI/t9HnJvo8EHRAw==",
+      "dev": true,
+      "requires": {
+        "@mongosh/async-rewriter": "^0.0.1-alpha.13",
+        "@mongosh/mapper": "^0.0.1-alpha.13",
+        "@mongosh/service-provider-core": "^0.0.1-alpha.13",
+        "@mongosh/shell-api": "^0.0.1-alpha.13"
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
@@ -1922,6 +2834,12 @@
         "@nodelib/fs.scandir": "2.1.3",
         "fastq": "^1.6.0"
       }
+    },
+    "@sheerun/mutationobserver-shim": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.3.tgz",
+      "integrity": "sha512-DetpxZw1fzPD5xUBrIAoplLChO2VB8DlL5Gg+I1IR9b2wPqYIca2WSUxL5g1vLeR4MsQq1NeWriXAVffV+U1Fw==",
+      "dev": true
     },
     "@sinonjs/commons": {
       "version": "1.7.1",
@@ -1958,6 +2876,70 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
+    },
+    "@testing-library/dom": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-5.6.1.tgz",
+      "integrity": "sha512-Y1T2bjtvQMewffn1CJ28kpgnuvPYKsBcZMagEH0ppfEMZPDc8AkkEnTk4smrGZKw0cblNB3lhM2FMnpfLExlHg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "@sheerun/mutationobserver-shim": "^0.3.2",
+        "aria-query": "3.0.0",
+        "pretty-format": "^24.8.0",
+        "wait-for-expect": "^1.2.0"
+      }
+    },
+    "@testing-library/react": {
+      "version": "8.0.9",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-8.0.9.tgz",
+      "integrity": "sha512-I7zd+MW5wk8rQA5VopZgBfxGKUd91jgZ6Vzj2gMqFf2iGGtKwvI5SVTrIJcSFaOXK88T2EUsbsIKugDtoqOcZQ==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "@testing-library/dom": "^5.6.1"
+      }
+    },
+    "@types/babel__core": {
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.7.tgz",
+      "integrity": "sha512-RL62NqSFPCDK2FM1pSDH0scHpJvsXtZNiYlMB73DgPBaG1E38ZYVL+ei5EkWRbr+KC4YNiAUNBnRj+bgwpgjMw==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "@types/babel__generator": {
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.1.tgz",
+      "integrity": "sha512-bBKm+2VPJcMRVwNhxKu8W+5/zT7pwNEqeokFOmbvVSqGzFneNxYcEBro9Ac7/N9tlsaPYnZLK8J1LWKkMsLAew==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@types/babel__template": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.0.2.tgz",
+      "integrity": "sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@types/babel__traverse": {
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.11.tgz",
+      "integrity": "sha512-ddHK5icION5U6q11+tV2f9Mo6CZVuT8GJKld2q9LqHSZbvLbH34Kcu2yFGckZut453+eQU6btIA3RihmnRgI+Q==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.3.0"
+      }
     },
     "@types/color-name": {
       "version": "1.1.1",
@@ -2003,6 +2985,31 @@
         }
       }
     },
+    "@types/istanbul-lib-coverage": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
+      "integrity": "sha512-hRJD2ahnnpLgsj6KWMYSrmXkM3rm2Dl1qkx6IOFD5FnuNPXJIG5L0dhgKXCYTRMGzU4n0wImQ/xfmRc4POUFlg==",
+      "dev": true
+    },
+    "@types/istanbul-lib-report": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+      "integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "@types/istanbul-reports": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
+      "integrity": "sha512-UpYjBi8xefVChsCoBpKShdxTllC9pwISirfoZsUa2AAdQg/Jd2KQGtSbw+ya7GPo7x/wAPlH6JBhKhAsXUEZNA==",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-coverage": "*",
+        "@types/istanbul-lib-report": "*"
+      }
+    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -2013,6 +3020,12 @@
       "version": "10.17.14",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.14.tgz",
       "integrity": "sha512-G0UmX5uKEmW+ZAhmZ6PLTQ5eu/VPaT+d/tdLd5IFsKRPcbe6lPxocBtcYBFSaLaCW8O60AX90e91Nsp8lVHCNw==",
+      "dev": true
+    },
+    "@types/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
     },
     "@types/prop-types": {
@@ -2030,6 +3043,21 @@
         "@types/prop-types": "*",
         "csstype": "^2.2.0"
       }
+    },
+    "@types/yargs": {
+      "version": "13.0.8",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.8.tgz",
+      "integrity": "sha512-XAvHLwG7UQ+8M4caKIH0ZozIOYay5fQkAgyIXegXT9jPtdIGdhga+sUEdAr1CiG46aB+c64xQEYyEzlwWVTNzA==",
+      "dev": true,
+      "requires": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "@types/yargs-parser": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-15.0.0.tgz",
+      "integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==",
+      "dev": true
     },
     "@typescript-eslint/typescript-estree": {
       "version": "2.19.2",
@@ -2597,11 +3625,26 @@
         "through2": "^0.6.3"
       }
     },
+    "ansi": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
+      "integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE=",
+      "dev": true
+    },
     "ansi-colors": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
       "integrity": "sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==",
       "dev": true
+    },
+    "ansi-escape-sequences": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-5.1.2.tgz",
+      "integrity": "sha512-JcpoVp1W1bl1Qn4cVuiXEhD6+dyXKSOgCn2zlzE8inYgCJCBy1aPnUhlz6I4DFum8D4ovb9Qi/iAjUcGvG2lqw==",
+      "dev": true,
+      "requires": {
+        "array-back": "^4.0.0"
+      }
     },
     "ansi-escapes": {
       "version": "3.2.0",
@@ -2733,6 +3776,12 @@
         }
       }
     },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -2740,6 +3789,16 @@
       "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "aria-query": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-3.0.0.tgz",
+      "integrity": "sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=",
+      "dev": true,
+      "requires": {
+        "ast-types-flow": "0.0.7",
+        "commander": "^2.11.0"
       }
     },
     "arr-diff": {
@@ -2758,6 +3817,12 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "dev": true
+    },
+    "array-back": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.1.tgz",
+      "integrity": "sha512-Z/JnaVEXv+A9xabHzN43FiiiWEE7gPCRXMrVmRm00tWbjZRul1iHm7ECzlyNq1p4a4ATXz+G9FJ3GqGOkOV3fg==",
       "dev": true
     },
     "array-find-index": {
@@ -2913,6 +3978,12 @@
       "integrity": "sha512-zXSoVaMrf2R+r+ISid5/9a8SXm1LLdkhHzh6pSRhj9jklzruOOl1hva1YmFT33wAstg/f9ZndJAlq1BSrFLSGA==",
       "dev": true
     },
+    "ast-types-flow": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
+      "integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0=",
+      "dev": true
+    },
     "astral-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
@@ -2947,6 +4018,12 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "dev": true
+    },
+    "atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
       "dev": true
     },
     "autoprefixer": {
@@ -3515,6 +4592,92 @@
       "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-emotion": {
+      "version": "10.0.33",
+      "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.0.33.tgz",
+      "integrity": "sha512-bxZbTTGz0AJQDHm8k6Rf3RQJ8tX2scsfsRyKVgAbiUPUNIRtlK+7JxP+TAd1kRLABFxe0CFm2VdK4ePkoA9FxQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@emotion/hash": "0.8.0",
+        "@emotion/memoize": "0.7.4",
+        "@emotion/serialize": "^0.11.16",
+        "babel-plugin-macros": "^2.0.0",
+        "babel-plugin-syntax-jsx": "^6.18.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^1.0.5",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7"
+      },
+      "dependencies": {
+        "find-root": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+          "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+          "dev": true
+        }
+      }
+    },
+    "babel-plugin-macros": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
+      "integrity": "sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.7.2",
+        "cosmiconfig": "^6.0.0",
+        "resolve": "^1.12.0"
+      },
+      "dependencies": {
+        "cosmiconfig": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
+          "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+          "dev": true,
+          "requires": {
+            "@types/parse-json": "^4.0.0",
+            "import-fresh": "^3.1.0",
+            "parse-json": "^5.0.0",
+            "path-type": "^4.0.0",
+            "yaml": "^1.7.2"
+          }
+        },
+        "import-fresh": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
+          "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+          "dev": true,
+          "requires": {
+            "parent-module": "^1.0.0",
+            "resolve-from": "^4.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
+          "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1",
+            "lines-and-columns": "^1.1.6"
+          }
+        },
+        "path-type": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+          "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+          "dev": true
+        },
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+          "dev": true
+        }
       }
     },
     "babel-plugin-syntax-async-functions": {
@@ -5951,6 +7114,30 @@
         "elliptic": "^6.0.0"
       }
     },
+    "create-emotion": {
+      "version": "10.0.27",
+      "resolved": "https://registry.npmjs.org/create-emotion/-/create-emotion-10.0.27.tgz",
+      "integrity": "sha512-fIK73w82HPPn/RsAij7+Zt8eCE8SptcJ3WoRMfxMtjteYxud8GDTKKld7MYwAX2TVhrw29uR1N/bVGxeStHILg==",
+      "dev": true,
+      "requires": {
+        "@emotion/cache": "^10.0.27",
+        "@emotion/serialize": "^0.11.15",
+        "@emotion/sheet": "0.9.4",
+        "@emotion/utils": "0.11.3"
+      }
+    },
+    "create-emotion-server": {
+      "version": "10.0.27",
+      "resolved": "https://registry.npmjs.org/create-emotion-server/-/create-emotion-server-10.0.27.tgz",
+      "integrity": "sha512-1EbZgdjiho9ue1BSTpAez8SIdfbTXomtz0bg+LPOEvf/5OV7xqCGJaoSCDCB+y7kZ73hwoEhLsoPmqKSGIQMXg==",
+      "dev": true,
+      "requires": {
+        "@emotion/utils": "0.11.3",
+        "html-tokenize": "^2.0.0",
+        "multipipe": "^1.0.2",
+        "through": "^2.3.8"
+      }
+    },
     "create-hash": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
@@ -7257,6 +8444,53 @@
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
       "dev": true
     },
+    "duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^2.0.2"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
     "duplexify": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
@@ -7625,6 +8859,60 @@
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
       "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
       "dev": true
+    },
+    "emotion": {
+      "version": "10.0.27",
+      "resolved": "https://registry.npmjs.org/emotion/-/emotion-10.0.27.tgz",
+      "integrity": "sha512-2xdDzdWWzue8R8lu4G76uWX5WhyQuzATon9LmNeCy/2BHVC6dsEpfhN1a0qhELgtDVdjyEA6J8Y/VlI5ZnaH0g==",
+      "dev": true,
+      "requires": {
+        "babel-plugin-emotion": "^10.0.27",
+        "create-emotion": "^10.0.27"
+      }
+    },
+    "emphasize": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/emphasize/-/emphasize-3.0.0.tgz",
+      "integrity": "sha512-xhtAWvxdkxsQbcCLGVjlfB7cQ4bWSPYXeaGDwK5Bl7n2y/9R+MVK5UNBTmZ9N8m/YShsiyGgQBgFGcjOWCWXHQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^3.0.0",
+        "highlight.js": "~9.12.0",
+        "lowlight": "~1.9.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "highlight.js": {
+          "version": "9.12.0",
+          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.12.0.tgz",
+          "integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
     },
     "encodeurl": {
       "version": "1.0.2",
@@ -8702,6 +9990,12 @@
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
     },
+    "facepaint": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/facepaint/-/facepaint-1.2.1.tgz",
+      "integrity": "sha512-oNvBekbhsm/0PNSOWca5raHNAi6dG960Bx6LJgxDPNF59WpuspgQ17bN5MKwOr7JcFdQYc7StW3VZ28DBZLavQ==",
+      "dev": true
+    },
     "fast-deep-equal": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
@@ -8793,6 +10087,18 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fast-redact": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-2.0.0.tgz",
+      "integrity": "sha512-zxpkULI9W9MNTK2sJ3BpPQrTEXFNESd2X6O1tXMFpK/XM0G5c5Rll2EVYZH2TqI3xRGK/VaJ+eEOt7pnENJpeA==",
+      "dev": true
+    },
+    "fast-safe-stringify": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==",
+      "dev": true
+    },
     "fastparse": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz",
@@ -8806,6 +10112,15 @@
       "dev": true,
       "requires": {
         "reusify": "^1.0.0"
+      }
+    },
+    "fault": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/fault/-/fault-1.0.4.tgz",
+      "integrity": "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==",
+      "dev": true,
+      "requires": {
+        "format": "^0.2.0"
       }
     },
     "faye-websocket": {
@@ -9050,6 +10365,12 @@
         }
       }
     },
+    "flatstr": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.12.tgz",
+      "integrity": "sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw==",
+      "dev": true
+    },
     "flatted": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
@@ -9210,6 +10531,12 @@
         "combined-stream": "^1.0.6",
         "mime-types": "^2.1.12"
       }
+    },
+    "format": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+      "integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs=",
+      "dev": true
     },
     "forwarded": {
       "version": "0.1.2",
@@ -10912,6 +12239,12 @@
       "integrity": "sha512-OrVKYz70LHsnCgmbXctv/bfuvntIKDz177h0Co37DQ5jamGZLVmoCVMtjMtNZY3X9DrCcKfklHPNeA0uPZhSJg==",
       "dev": true
     },
+    "highlightjs-graphql": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/highlightjs-graphql/-/highlightjs-graphql-1.0.1.tgz",
+      "integrity": "sha512-g5kt/orsUJTjIt5pgs/uvi78kXndpCtYwzE7H3D0d07r3ETs9oHSZHD0EGaRPndiQ/4EYXt12rnsDkljn3ilAA==",
+      "dev": true
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -11118,6 +12451,58 @@
               "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
               "dev": true
             }
+          }
+        }
+      }
+    },
+    "html-tokenize": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/html-tokenize/-/html-tokenize-2.0.1.tgz",
+      "integrity": "sha512-QY6S+hZ0f5m1WT8WffYN+Hg+xm/w5I8XeUcAq/ZYP5wVC8xbKi4Whhru3FtrAebD5EhBW8rmFzkDI6eCAuFe2w==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "~0.1.1",
+        "inherits": "~2.0.1",
+        "minimist": "~1.2.5",
+        "readable-stream": "~1.0.27-1",
+        "through2": "~0.4.1"
+      },
+      "dependencies": {
+        "buffer-from": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.2.tgz",
+          "integrity": "sha512-RiWIenusJsmI2KcvqQABB83tLxCByE3upSP8QU3rJDMVFGPWLvPQJt/O1Su9moRWeH7d+Q2HYb68f6+v+tw2vg==",
+          "dev": true
+        },
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        },
+        "object-keys": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+          "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=",
+          "dev": true
+        },
+        "through2": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
+          "integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=",
+          "dev": true,
+          "requires": {
+            "readable-stream": "~1.0.17",
+            "xtend": "~2.1.1"
+          }
+        },
+        "xtend": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+          "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
+          "dev": true,
+          "requires": {
+            "object-keys": "~0.4.0"
           }
         }
       }
@@ -13061,6 +14446,12 @@
         "immediate": "~3.0.5"
       }
     },
+    "lines-and-columns": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+      "dev": true
+    },
     "load-json-file": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
@@ -14399,6 +15790,12 @@
         "lodash.values": "^3.0.0"
       }
     },
+    "lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
+      "dev": true
+    },
     "lodash.shuffle": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.shuffle/-/lodash.shuffle-3.1.0.tgz",
@@ -14645,6 +16042,24 @@
       "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
       "dev": true
     },
+    "lowlight": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.9.2.tgz",
+      "integrity": "sha512-Ek18ElVCf/wF/jEm1b92gTnigh94CtBNWiZ2ad+vTgW7cTmQxUY3I98BjHK68gZAJEWmybGBZgx9qv3QxLQB/Q==",
+      "dev": true,
+      "requires": {
+        "fault": "^1.0.2",
+        "highlight.js": "~9.12.0"
+      },
+      "dependencies": {
+        "highlight.js": {
+          "version": "9.12.0",
+          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.12.0.tgz",
+          "integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4=",
+          "dev": true
+        }
+      }
+    },
     "lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -14670,6 +16085,12 @@
           "dev": true
         }
       }
+    },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
     },
     "mamacro": {
       "version": "0.0.3",
@@ -15653,6 +17074,12 @@
       "integrity": "sha512-hwavJifXXWXMBX5tscRmM3eIR83M2oESaHRxgsNUbC/tkxyh14EvIkpIh1dFBSbQSGc2B8YRywlLlrgKyBgUiA==",
       "dev": true
     },
+    "mongodb-build-info": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mongodb-build-info/-/mongodb-build-info-1.0.0.tgz",
+      "integrity": "sha512-ZFcBteBQMoGyMV3+FmjPRRI4X2ZR8TNPGlylNuGU1yg/TTC7eXFcd2VhL7SslRM0/tGsx7pIjLEqwjd9CtWSlA==",
+      "dev": true
+    },
     "mongodb-collection-model": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/mongodb-collection-model/-/mongodb-collection-model-2.0.4.tgz",
@@ -16579,6 +18006,15 @@
         }
       }
     },
+    "mongodb-redact": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/mongodb-redact/-/mongodb-redact-0.2.0.tgz",
+      "integrity": "sha512-kGoR02HsTzNYHFXLklvbEg7mSJZu5+L1JdaYUuSlmVUAXxzhxUBvoFoYulfqqvokE+ilAXGYywdMJStB0lPhCw==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.15"
+      }
+    },
     "mongodb-redux-common": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/mongodb-redux-common/-/mongodb-redux-common-0.0.2.tgz",
@@ -16932,6 +18368,22 @@
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
       "dev": true
     },
+    "multipipe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-1.0.2.tgz",
+      "integrity": "sha1-zBPv2DPJzamfIk+GhGG44aP9k50=",
+      "dev": true,
+      "requires": {
+        "duplexer2": "^0.1.2",
+        "object-assign": "^4.1.0"
+      }
+    },
+    "mustache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.0.1.tgz",
+      "integrity": "sha512-yL5VE97+OXn4+Er3THSmTdCFCtx5hHWzrolvH+JObZnUYwuaG7XV+Ch4fR2cIrcYI0tFHxS7iyFYl14bW8y2sA==",
+      "dev": true
+    },
     "mute-stream": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
@@ -16943,6 +18395,23 @@
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
       "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
       "dev": true
+    },
+    "nanoassert": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-1.1.0.tgz",
+      "integrity": "sha1-TzFS4JVA/eKMdvRLGbvNHVpCR40=",
+      "dev": true
+    },
+    "nanobus": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/nanobus/-/nanobus-4.4.0.tgz",
+      "integrity": "sha512-Hv9USGyH8EsPy0o8pPWE7x3YRIfuZDgMBirzjU6XLebhiSK2g53JlfqgolD0c39ne6wXAfaBNcIAvYe22Bav+Q==",
+      "dev": true,
+      "requires": {
+        "nanoassert": "^1.1.0",
+        "nanotiming": "^7.2.0",
+        "remove-array-items": "^1.0.0"
+      }
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -16969,6 +18438,25 @@
           "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
           "dev": true
         }
+      }
+    },
+    "nanoscheduler": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/nanoscheduler/-/nanoscheduler-1.0.3.tgz",
+      "integrity": "sha512-jBbrF3qdU9321r8n9X7yu18DjP31Do2ItJm3mWrt90wJTrnDO+HXpoV7ftaUglAtjgj9s+OaCxGufbvx6pvbEQ==",
+      "dev": true,
+      "requires": {
+        "nanoassert": "^1.1.0"
+      }
+    },
+    "nanotiming": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/nanotiming/-/nanotiming-7.3.1.tgz",
+      "integrity": "sha512-l3lC7v/PfOuRWQa8vV29Jo6TG10wHtnthLElFXs4Te4Aas57Fo4n1Q8LH9n+NDh9riOzTVvb2QNBhTS4JUKNjw==",
+      "dev": true,
+      "requires": {
+        "nanoassert": "^1.1.0",
+        "nanoscheduler": "^1.0.2"
       }
     },
     "napi-build-utils": {
@@ -18267,6 +19755,26 @@
         "pinkie": "^2.0.0"
       }
     },
+    "pino": {
+      "version": "5.17.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-5.17.0.tgz",
+      "integrity": "sha512-LqrqmRcJz8etUjyV0ddqB6OTUutCgQULPFg2b4dtijRHUsucaAdBgSUW58vY6RFSX+NT8963F+q0tM6lNwGShA==",
+      "dev": true,
+      "requires": {
+        "fast-redact": "^2.0.0",
+        "fast-safe-stringify": "^2.0.7",
+        "flatstr": "^1.0.12",
+        "pino-std-serializers": "^2.4.2",
+        "quick-format-unescaped": "^3.0.3",
+        "sonic-boom": "^0.7.5"
+      }
+    },
+    "pino-std-serializers": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-2.4.2.tgz",
+      "integrity": "sha512-WaL504dO8eGs+vrK+j4BuQQq6GLKeCCcHaMB2ItygzVURcL1CycwNEUHTD/lHFHs/NL5qAz2UKrjYWXKSf4aMQ==",
+      "dev": true
+    },
     "pkg-dir": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
@@ -18370,6 +19878,15 @@
           "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "dev": true
         }
+      }
+    },
+    "polished": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/polished/-/polished-2.3.3.tgz",
+      "integrity": "sha512-59V4fDbdxtH4I1m9TWxFsoGJbC8nnOpUYo5uFmvMfKp9Qh+6suo4VMUle1TGIIUZIGxfkW+Rs485zPk0wcwR2Q==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.2.0"
       }
     },
     "popmotion": {
@@ -20302,6 +21819,95 @@
         "utila": "~0.4"
       }
     },
+    "pretty-format": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
+      "integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^24.9.0",
+        "ansi-regex": "^4.0.0",
+        "ansi-styles": "^3.2.0",
+        "react-is": "^16.8.4"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "dev": true
+        }
+      }
+    },
+    "pretty-repl": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-repl/-/pretty-repl-2.3.0.tgz",
+      "integrity": "sha512-h7iNPLXpJPnbZZS0YIp1+EGD+oY9STelL70X8nwzrbglqP5nOUi0YxK+OJ8n6xopVHoLNQZrytYTmHrWcB1O/w==",
+      "dev": true,
+      "requires": {
+        "ansi": "^0.3.1",
+        "chalk": "^4.0.0",
+        "emphasize": "^3.0.0",
+        "semver": "^7.2.2"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.0.0.tgz",
+          "integrity": "sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
@@ -20573,6 +22179,12 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
       "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==",
+      "dev": true
+    },
+    "quick-format-unescaped": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-3.0.3.tgz",
+      "integrity": "sha512-dy1yjycmn9blucmJLXOfZDx1ikZJUi6E8bBZLnhPG5gBrVhHXx2xVyqqgKBubVNEXmx51dBACMHpoMQK/N/AXQ==",
       "dev": true
     },
     "raf": {
@@ -20952,6 +22564,15 @@
         "react-lifecycles-compat": "^3.0.4"
       }
     },
+    "read": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+      "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+      "dev": true,
+      "requires": {
+        "mute-stream": "~0.0.4"
+      }
+    },
     "read-package-json": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.1.1.tgz",
@@ -21285,6 +22906,12 @@
       "requires": {
         "es6-error": "^4.0.1"
       }
+    },
+    "remove-array-items": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/remove-array-items/-/remove-array-items-1.1.1.tgz",
+      "integrity": "sha512-MXW/jtHyl5F1PZI7NbpS8SOtympdLuF20aoWJT5lELR1p/HJDd5nqW8Eu9uLh/hCRY3FgvrIT5AwDCgBODklcA==",
+      "dev": true
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
@@ -22312,6 +23939,16 @@
             "websocket-driver": ">=0.5.1"
           }
         }
+      }
+    },
+    "sonic-boom": {
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-0.7.7.tgz",
+      "integrity": "sha512-Ei5YOo5J64GKClHIL/5evJPgASXFVpfVYbJV9PILZQytTK6/LCwHvsZJW2Ig4p9FMC2OrBrMnXKgRN/OEoAWfg==",
+      "dev": true,
+      "requires": {
+        "atomic-sleep": "^1.0.0",
+        "flatstr": "^1.0.12"
       }
     },
     "sort-keys": {
@@ -23540,6 +25177,43 @@
       "integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==",
       "dev": true
     },
+    "ts-node": {
+      "version": "8.10.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.10.1.tgz",
+      "integrity": "sha512-bdNz1L4ekHiJul6SHtZWs1ujEKERJnHs4HxN7rjTyyVOFf3HaJ6sLqe6aPG62XTzAB/63pKRh5jTSWL0D7bsvw==",
+      "dev": true,
+      "requires": {
+        "arg": "^4.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.17",
+        "yn": "3.1.1"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "source-map-support": {
+          "version": "0.5.19",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+          "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+          "dev": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          }
+        }
+      }
+    },
     "tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
@@ -24022,6 +25696,12 @@
       "requires": {
         "xml-name-validator": "^3.0.0"
       }
+    },
+    "wait-for-expect": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/wait-for-expect/-/wait-for-expect-1.3.0.tgz",
+      "integrity": "sha512-8fJU7jiA96HfGPt+P/UilelSAZfhMBJ52YhKzlmZQvKEZU2EcD1GQ0yqGB6liLdHjYtYAoGVigYwdxr5rktvzA==",
+      "dev": true
     },
     "warning": {
       "version": "3.0.0",
@@ -24953,6 +26633,32 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true
     },
+    "yaml": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.9.2.tgz",
+      "integrity": "sha512-HPT7cGGI0DuRcsO51qC1j9O16Dh1mZ2bnXwsi0jrSpsLz0WxOLSLXfkABVl6bZO629py3CU+OMJtpNHDLB97kg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.6.tgz",
+          "integrity": "sha512-64AF1xY3OAkFHqOb9s4jpgk1Mm5vDZ4L3acHvAml+53nO1XbXLuDodsVpO4OIUsmemlUHMxNdYMNJmsvOwLrvQ==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
+          "dev": true
+        }
+      }
+    },
     "yargs": {
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.1.0.tgz",
@@ -25029,6 +26735,12 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
       "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk=",
+      "dev": true
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "dev": true
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10689,25 +10689,29 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true,
           "optional": true
         },
         "aproba": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -10717,13 +10721,15 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true,
           "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -10733,37 +10739,43 @@
         },
         "chownr": {
           "version": "1.1.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==",
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true,
           "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true,
           "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "dev": true,
           "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true,
           "optional": true
         },
         "debug": {
           "version": "3.2.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -10772,25 +10784,29 @@
         },
         "deep-extend": {
           "version": "0.6.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "dev": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.7",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -10799,13 +10815,15 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -10821,7 +10839,8 @@
         },
         "glob": {
           "version": "7.1.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -10835,13 +10854,15 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -10850,7 +10871,8 @@
         },
         "ignore-walk": {
           "version": "3.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -10859,7 +10881,8 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -10869,19 +10892,22 @@
         },
         "inherits": {
           "version": "2.0.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
           "dev": true,
           "optional": true
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -10890,13 +10916,15 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -10905,13 +10933,15 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true,
           "optional": true
         },
         "minipass": {
           "version": "2.9.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -10921,7 +10951,8 @@
         },
         "minizlib": {
           "version": "1.3.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -10930,7 +10961,8 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -10939,13 +10971,15 @@
         },
         "ms": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.4.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -10956,7 +10990,8 @@
         },
         "node-pre-gyp": {
           "version": "0.14.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -10974,7 +11009,8 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -10984,7 +11020,8 @@
         },
         "npm-bundled": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -10993,13 +11030,15 @@
         },
         "npm-normalize-package-bin": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.4.7",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-vAj7dIkp5NhieaGZxBJB8fF4R0078rqsmhJcAfXZ6O7JJhjhPK96n5Ry1oZcfLXgfun0GWTZPOxaEyqv8GBykQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -11009,7 +11048,8 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -11021,19 +11061,22 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true,
           "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -11042,19 +11085,22 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -11064,19 +11110,22 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.8",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -11088,7 +11137,8 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
             }
@@ -11096,7 +11146,8 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -11111,7 +11162,8 @@
         },
         "rimraf": {
           "version": "2.7.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -11120,43 +11172,50 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
           "dev": true,
           "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.7.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -11167,7 +11226,8 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -11176,7 +11236,8 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -11185,13 +11246,15 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.13",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -11206,13 +11269,15 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -11221,13 +11286,15 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true,
           "optional": true
         },
         "yallist": {
           "version": "3.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
           "dev": true,
           "optional": true
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2265,14 +2265,14 @@
       }
     },
     "@mongodb-js/compass-shell": {
-      "version": "0.0.1-alpha.14",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-shell/-/compass-shell-0.0.1-alpha.14.tgz",
-      "integrity": "sha512-BnrG0Sq5TYlM8wInfxP2N4oaPH4S06nZG2Q9s0eqtQ0Y5Dvt5QUoEcn8hS8M+I5NTcrR/Pglf4y6JB+vRjSjdw==",
+      "version": "0.0.1-alpha.13",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-shell/-/compass-shell-0.0.1-alpha.13.tgz",
+      "integrity": "sha512-vKBKRGU+sDAOU2oXMWtcDd5QA6qRJ/tzvsw85R2YL5BDOvrFDBqpT7B79MqQRKXWG76oBRnzaoGwPaMd41SiOQ==",
       "dev": true,
       "requires": {
-        "@mongosh/browser-repl": "^0.0.1-alpha.14",
-        "@mongosh/browser-runtime-electron": "^0.0.1-alpha.14",
-        "@mongosh/service-provider-server": "^0.0.1-alpha.14"
+        "@mongosh/browser-repl": "^0.0.1-alpha.13",
+        "@mongosh/browser-runtime-electron": "^0.0.1-alpha.13",
+        "@mongosh/service-provider-server": "^0.0.1-alpha.13"
       }
     },
     "@mongodb-js/compass-sidebar": {
@@ -2470,9 +2470,9 @@
           "dev": true
         },
         "typescript": {
-          "version": "3.8.3",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-          "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+          "version": "3.9.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.2.tgz",
+          "integrity": "sha512-q2ktq4n/uLuNNShyayit+DTobV2ApPEo/6so68JaD5ojvc/6GClBipedB9zNWYxRSAlZXAe405Rlijzl6qDiSw==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@mongodb-js/compass-schema-validation": "*",
     "@mongodb-js/compass-server-version": "*",
     "@mongodb-js/compass-serverstats": "*",
-    "@mongodb-js/compass-shell": "^0.0.1-alpha.13",
+    "@mongodb-js/compass-shell": "0.0.1-alpha.13",
     "@mongodb-js/compass-sidebar": "*",
     "@mongodb-js/compass-ssh-tunnel-status": "*",
     "@mongodb-js/compass-status": "*",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@mongodb-js/compass-schema-validation": "*",
     "@mongodb-js/compass-server-version": "*",
     "@mongodb-js/compass-serverstats": "*",
-    "@mongodb-js/compass-shell": "^0.0.1-alpha.13",
+    "@mongodb-js/compass-shell": "^0.0.1-alpha.14",
     "@mongodb-js/compass-sidebar": "*",
     "@mongodb-js/compass-ssh-tunnel-status": "*",
     "@mongodb-js/compass-status": "*",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@mongodb-js/compass-schema-validation": "*",
     "@mongodb-js/compass-server-version": "*",
     "@mongodb-js/compass-serverstats": "*",
-    "@mongodb-js/compass-shell": "^0.0.1-alpha.14",
+    "@mongodb-js/compass-shell": "^0.0.1-alpha.13",
     "@mongodb-js/compass-sidebar": "*",
     "@mongodb-js/compass-ssh-tunnel-status": "*",
     "@mongodb-js/compass-status": "*",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@mongodb-js/compass-schema-validation": "*",
     "@mongodb-js/compass-server-version": "*",
     "@mongodb-js/compass-serverstats": "*",
+    "@mongodb-js/compass-shell": "*",
     "@mongodb-js/compass-sidebar": "*",
     "@mongodb-js/compass-ssh-tunnel-status": "*",
     "@mongodb-js/compass-status": "*",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@mongodb-js/compass-schema-validation": "*",
     "@mongodb-js/compass-server-version": "*",
     "@mongodb-js/compass-serverstats": "*",
-    "@mongodb-js/compass-shell": "*",
+    "@mongodb-js/compass-shell": "^0.0.1-alpha.13",
     "@mongodb-js/compass-sidebar": "*",
     "@mongodb-js/compass-ssh-tunnel-status": "*",
     "@mongodb-js/compass-status": "*",

--- a/src/assets/less/compass/_tab-nav-bar.less
+++ b/src/assets/less/compass/_tab-nav-bar.less
@@ -7,6 +7,7 @@
     display: flex;
     flex-direction: column;
     align-items: stretch;
+    overflow: auto;
   }
 
   &-header {

--- a/src/assets/less/home.less
+++ b/src/assets/less/home.less
@@ -61,6 +61,7 @@ GLOBAL FLEXBOX LAYOUT STYLES
   align-items: stretch;
   width: 100%;
   flex-grow: 1;
+  overflow: auto;
 }
 
 .controls-container {
@@ -125,6 +126,7 @@ GLOBAL FLEXBOX LAYOUT STYLES
   align-items: stretch;
   width: 100%;
   flex-grow: 1;
+  overflow: auto;
 
   &-has-error {
     color: red;

--- a/src/components/home/home.jsx
+++ b/src/components/home/home.jsx
@@ -208,10 +208,10 @@ class Home extends PureComponent {
           </div>
           {this.renderSidebar()}
           {this.renderFindInPage()}
-          {this.renderGlobalModals()}
-          {this.renderGlobalWarnings()}
-          {this.renderGlobalShell()}
         </div>
+        {this.renderGlobalModals()}
+        {this.renderGlobalWarnings()}
+        {this.renderGlobalShell()}
       </div>
     );
   }

--- a/src/components/home/home.jsx
+++ b/src/components/home/home.jsx
@@ -75,6 +75,7 @@ class Home extends PureComponent {
     this.databaseRole = this.getRoleOrNull('Database.Workspace');
     this.instanceRole = this.getRoleOrNull('Instance.Workspace');
     this.globalModals = this.getRoleOrNull('Global.Modal');
+    this.globalShellComponent = this.getComponentOrNull('Global.Shell');
     this.globalWarnings = this.getRoleOrNull('Global.Warning');
     this.findInPageRole = this.getRoleOrNull('Find');
   }
@@ -172,6 +173,14 @@ class Home extends PureComponent {
     return null;
   }
 
+  renderGlobalShell() {
+    if (this.globalShellComponent) {
+      const GlobalShellComponent = this.globalShellComponent;
+      return <GlobalShellComponent />;
+    }
+    return null;
+  }
+
   renderGlobalWarnings() {
     if (this.globalWarnings) {
       return this.globalWarnings.map((globalWarning, index) => {
@@ -201,6 +210,7 @@ class Home extends PureComponent {
           {this.renderFindInPage()}
           {this.renderGlobalModals()}
           {this.renderGlobalWarnings()}
+          {this.renderGlobalShell()}
         </div>
       </div>
     );

--- a/src/components/home/home.less
+++ b/src/components/home/home.less
@@ -11,6 +11,8 @@
     flex-direction: row;
     align-items: stretch;
     flex: 1;
+    height: 100%;
+
     &-content {
       flex-grow: 1;
       flex-shrink: 1;

--- a/src/components/home/home.less
+++ b/src/components/home/home.less
@@ -12,6 +12,7 @@
     align-items: stretch;
     flex: 1;
     height: 100%;
+    z-index: 0;
 
     &-content {
       flex-grow: 1;

--- a/src/components/home/home.spec.js
+++ b/src/components/home/home.spec.js
@@ -33,7 +33,6 @@ describe('Home [Component]', () => {
 
     global.hadronApp.appRegistry.registerComponent('Sidebar.Component', SidebarPlugin);
     global.hadronApp.appRegistry.registerComponent('Global.Shell', ShellPlugin);
-    // TODO: Register the shell here and pull it into the tests.
     [
       'Collection.Workspace', 'Database.Workspace', 'Instance.Workspace', 'Find',
       'Global.Modal', 'Application.Connect'

--- a/src/components/home/home.spec.js
+++ b/src/components/home/home.spec.js
@@ -101,11 +101,11 @@ describe('Home [Component]', () => {
       it('renders the find', () => {
         expect(component.find('.Find')).to.be.present();
       });
-      it('renders the global', () => {
-        expect(component.find('.Global')).to.be.present();
-      });
       it('renders the shell plugin', () => {
         expect(component.find(ShellPlugin)).to.be.present();
+      });
+      it('renders the global', () => {
+        expect(component.find('.Global')).to.be.present();
       });
     });
     describe('UI status is error', () => {
@@ -180,11 +180,11 @@ describe('Home [Component]', () => {
         it('renders the find', () => {
           expect(component.find('.Find')).to.be.present();
         });
-        it('renders the global', () => {
-          expect(component.find('.Global')).to.be.present();
-        });
         it('renders the shell plugin', () => {
           expect(component.find(ShellPlugin)).to.be.present();
+        });
+        it('renders the global', () => {
+          expect(component.find('.Global')).to.be.present();
         });
       });
       describe('namespace is only DB', () => {
@@ -216,11 +216,11 @@ describe('Home [Component]', () => {
         it('renders the find', () => {
           expect(component.find('.Find')).to.be.present();
         });
-        it('renders the global', () => {
-          expect(component.find('.Global')).to.be.present();
-        });
         it('renders the shell plugin', () => {
           expect(component.find(ShellPlugin)).to.be.present();
+        });
+        it('renders the global', () => {
+          expect(component.find('.Global')).to.be.present();
         });
       });
       describe('namespace is db and coll', () => {
@@ -288,11 +288,11 @@ describe('Home [Component]', () => {
         it('renders the find', () => {
           expect(component.find('.Find')).to.be.present();
         });
-        it('renders the global', () => {
-          expect(component.find('.Global')).to.be.present();
-        });
         it('renders the shell plugin', () => {
           expect(component.find(ShellPlugin)).to.be.present();
+        });
+        it('renders the global', () => {
+          expect(component.find('.Global')).to.be.present();
         });
       });
       describe('toggleIsCollapsed', () => {

--- a/src/components/home/home.spec.js
+++ b/src/components/home/home.spec.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 import AppRegistry from 'hadron-app-registry';
 import SidebarPlugin from '@mongodb-js/compass-sidebar';
+import ShellPlugin from '@mongodb-js/compass-shell';
 
 import classnames from 'classnames';
 import styles from './home.less';
@@ -31,6 +32,8 @@ describe('Home [Component]', () => {
 
 
     global.hadronApp.appRegistry.registerComponent('Sidebar.Component', SidebarPlugin);
+    global.hadronApp.appRegistry.registerComponent('Global.Shell', ShellPlugin);
+    // TODO: Register the shell here and pull it into the tests.
     [
       'Collection.Workspace', 'Database.Workspace', 'Instance.Workspace', 'Find',
       'Global.Modal', 'Application.Connect'
@@ -102,6 +105,9 @@ describe('Home [Component]', () => {
       it('renders the global', () => {
         expect(component.find('.Global')).to.be.present();
       });
+      it('renders the shell plugin', () => {
+        expect(component.find(ShellPlugin)).to.be.present();
+      });
     });
     describe('UI status is error', () => {
       beforeEach(() => {
@@ -141,6 +147,9 @@ describe('Home [Component]', () => {
       it('renders the global', () => {
         expect(component.find('.Global')).to.be.present();
       });
+      it('renders the shell plugin', () => {
+        expect(component.find(ShellPlugin)).to.be.present();
+      });
     });
     describe('UI status is complete', () => {
       describe('namespace is unset', () => {
@@ -175,6 +184,9 @@ describe('Home [Component]', () => {
         it('renders the global', () => {
           expect(component.find('.Global')).to.be.present();
         });
+        it('renders the shell plugin', () => {
+          expect(component.find(ShellPlugin)).to.be.present();
+        });
       });
       describe('namespace is only DB', () => {
         beforeEach(() => {
@@ -207,6 +219,9 @@ describe('Home [Component]', () => {
         });
         it('renders the global', () => {
           expect(component.find('.Global')).to.be.present();
+        });
+        it('renders the shell plugin', () => {
+          expect(component.find(ShellPlugin)).to.be.present();
         });
       });
       describe('namespace is db and coll', () => {
@@ -241,6 +256,9 @@ describe('Home [Component]', () => {
         it('renders the global', () => {
           expect(component.find('.Global')).to.be.present();
         });
+        it('renders the shell plugin', () => {
+          expect(component.find(ShellPlugin)).to.be.present();
+        });
       });
       describe('isCollapsed is true', () => {
         beforeEach(() => {
@@ -273,6 +291,9 @@ describe('Home [Component]', () => {
         });
         it('renders the global', () => {
           expect(component.find('.Global')).to.be.present();
+        });
+        it('renders the shell plugin', () => {
+          expect(component.find(ShellPlugin)).to.be.present();
         });
       });
       describe('toggleIsCollapsed', () => {

--- a/styles/index.less
+++ b/styles/index.less
@@ -46,6 +46,7 @@ GLOBAL FLEXBOX LAYOUT STYLES
   flex-shrink: 1;
   flex-basis: auto;
   display: flex;
+  overflow: auto;
 }
 
 .tab {

--- a/styles/index.less
+++ b/styles/index.less
@@ -67,6 +67,7 @@ GLOBAL FLEXBOX LAYOUT STYLES
   align-items: stretch;
   width: 100%;
   flex-grow: 1;
+  overflow: auto;
 }
 
 .controls-container {
@@ -132,6 +133,7 @@ GLOBAL FLEXBOX LAYOUT STYLES
   align-items: stretch;
   width: 100%;
   flex-grow: 1;
+  overflow: auto;
 
   &-has-error {
     color: red;


### PR DESCRIPTION
https://jira.mongodb.org/browse/MONGOSH-89

This PR adds a `Global.Shell` component role to compass. We'll use this from the https://github.com/mongodb-js/mongosh/tree/master/packages/compass-shell plugin to act as an expandable bottom bar. I think we'll be able to do it purely through styles inside of the shell plugin so this should hopefully be the only change here. 

This doesn't have any functional changes yet because the compass shell component is not yet registering or bundled with compass. There are some styling changes which improve how components scroll on the y axis.

This PR goes in tandem with: https://github.com/mongodb-js/compass/pull/1961